### PR TITLE
Add utils for parsing a ed25519 private key and extracting the public key from a ed25519 private key

### DIFF
--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -1,0 +1,86 @@
+package crypto
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// ParseAndValidateEd25519PrivateKey parses and validates an ed25519 private key
+// and returns the ed25519.PrivateKey object. The input can be either raw bytes
+// or PEM-encoded private key.
+func ParseAndValidateEd25519PrivateKey(keyData []byte) (ed25519.PrivateKey, error) {
+	var privateKey ed25519.PrivateKey
+
+	// Try to decode as PEM first
+	if block, _ := pem.Decode(keyData); block != nil {
+		switch block.Type {
+		case "PRIVATE KEY":
+			// PKCS#8 format
+			key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse PKCS#8 private key: %w", err)
+			}
+
+			var ok bool
+			privateKey, ok = key.(ed25519.PrivateKey)
+			if !ok {
+				return nil, fmt.Errorf("key is not an ed25519 private key")
+			}
+		case "ED25519 PRIVATE KEY":
+			// Ed25519 specific format
+			key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse ed25519 private key: %w", err)
+			}
+
+			var ok bool
+			privateKey, ok = key.(ed25519.PrivateKey)
+			if !ok {
+				return nil, fmt.Errorf("key is not an ed25519 private key")
+			}
+		default:
+			return nil, fmt.Errorf("unsupported PEM block type: %s", block.Type)
+		}
+	} else {
+		// Try to parse as raw ed25519 private key
+		if len(keyData) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("invalid ed25519 private key size: expected %d bytes, got %d", ed25519.PrivateKeySize, len(keyData))
+		}
+		privateKey = ed25519.PrivateKey(keyData)
+	}
+
+	// Validate the private key by checking its length
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid ed25519 private key size: expected %d bytes, got %d", ed25519.PrivateKeySize, len(privateKey))
+	}
+
+	return privateKey, nil
+}
+
+// ExtractEd25519PublicKeyAsPEM extracts the public key from an ed25519 private key
+// and returns it in PEM format.
+func ExtractEd25519PublicKeyAsPEM(privateKey ed25519.PrivateKey) ([]byte, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid ed25519 private key size: expected %d bytes, got %d", ed25519.PrivateKeySize, len(privateKey))
+	}
+
+	// Extract the public key
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+
+	// Marshal the public key in PKIX format
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+
+	// Create PEM block
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyBytes,
+	}
+
+	// Encode to PEM format
+	return pem.EncodeToMemory(pemBlock), nil
+}

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -27,8 +27,13 @@ func TestParseAndValidateEd25519PrivateKey(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:      "Valid raw seed (32 bytes)",
+			keyData:   privateKey[:ed25519.SeedSize],
+			expectErr: false,
+		},
+		{
 			name:      "Invalid raw private key - wrong size",
-			keyData:   make([]byte, 32), // ed25519 private key should be 64 bytes
+			keyData:   make([]byte, 31),
 			expectErr: true,
 		},
 		{

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -1,0 +1,205 @@
+package crypto
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestParseAndValidateEd25519PrivateKey(t *testing.T) {
+	// Generate a test ed25519 key pair
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ed25519 key pair: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		keyData   []byte
+		expectErr bool
+	}{
+		{
+			name:      "Valid raw private key",
+			keyData:   privateKey,
+			expectErr: false,
+		},
+		{
+			name:      "Invalid raw private key - wrong size",
+			keyData:   make([]byte, 32), // ed25519 private key should be 64 bytes
+			expectErr: true,
+		},
+		{
+			name:      "Empty key data",
+			keyData:   []byte{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseAndValidateEd25519PrivateKey(tt.keyData)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if len(parsed) != ed25519.PrivateKeySize {
+				t.Errorf("Expected private key size %d, got %d", ed25519.PrivateKeySize, len(parsed))
+			}
+		})
+	}
+}
+
+func TestParseAndValidateEd25519PrivateKeyPEM(t *testing.T) {
+	// Generate a test ed25519 key pair
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ed25519 key pair: %v", err)
+	}
+
+	// Convert to PKCS#8 format
+	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to marshal private key: %v", err)
+	}
+
+	// Create PEM block
+	pemBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkcs8Bytes,
+	}
+	pemData := pem.EncodeToMemory(pemBlock)
+
+	parsed, err := ParseAndValidateEd25519PrivateKey(pemData)
+	if err != nil {
+		t.Errorf("Failed to parse PEM private key: %v", err)
+		return
+	}
+
+	if len(parsed) != ed25519.PrivateKeySize {
+		t.Errorf("Expected private key size %d, got %d", ed25519.PrivateKeySize, len(parsed))
+	}
+
+	// Verify the parsed key matches the original
+	if !ed25519.PrivateKey(parsed).Equal(privateKey) {
+		t.Errorf("Parsed private key does not match original")
+	}
+}
+
+func TestExtractEd25519PublicKeyAsPEM(t *testing.T) {
+	// Generate a test ed25519 key pair
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ed25519 key pair: %v", err)
+	}
+
+	// Extract public key as PEM
+	pemData, err := ExtractEd25519PublicKeyAsPEM(privateKey)
+	if err != nil {
+		t.Errorf("Failed to extract public key as PEM: %v", err)
+		return
+	}
+
+	// Verify it's valid PEM
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		t.Errorf("Failed to decode PEM data")
+		return
+	}
+
+	if block.Type != "PUBLIC KEY" {
+		t.Errorf("Expected PEM block type 'PUBLIC KEY', got '%s'", block.Type)
+	}
+
+	// Parse the public key from PEM
+	parsedPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Errorf("Failed to parse public key from PEM: %v", err)
+		return
+	}
+
+	// Verify it's an ed25519 public key
+	ed25519PublicKey, ok := parsedPublicKey.(ed25519.PublicKey)
+	if !ok {
+		t.Errorf("Parsed public key is not ed25519.PublicKey")
+		return
+	}
+
+	// Verify the extracted public key matches the original
+	if !ed25519PublicKey.Equal(publicKey) {
+		t.Errorf("Extracted public key does not match original")
+	}
+
+	// Verify PEM format contains expected headers
+	pemString := string(pemData)
+	if !strings.Contains(pemString, "-----BEGIN PUBLIC KEY-----") {
+		t.Errorf("PEM data missing BEGIN header")
+	}
+	if !strings.Contains(pemString, "-----END PUBLIC KEY-----") {
+		t.Errorf("PEM data missing END header")
+	}
+}
+
+func TestExtractEd25519PublicKeyAsPEMInvalidKey(t *testing.T) {
+	// Test with invalid private key
+	invalidKey := make([]byte, 32) // Wrong size
+
+	_, err := ExtractEd25519PublicKeyAsPEM(invalidKey)
+	if err == nil {
+		t.Errorf("Expected error for invalid private key size")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	// Generate a test ed25519 key pair
+	originalPublicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ed25519 key pair: %v", err)
+	}
+
+	// Parse and validate the private key
+	parsedPrivateKey, err := ParseAndValidateEd25519PrivateKey(privateKey)
+	if err != nil {
+		t.Errorf("Failed to parse private key: %v", err)
+		return
+	}
+
+	// Extract public key as PEM
+	pemData, err := ExtractEd25519PublicKeyAsPEM(parsedPrivateKey)
+	if err != nil {
+		t.Errorf("Failed to extract public key as PEM: %v", err)
+		return
+	}
+
+	// Parse the public key back from PEM
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		t.Errorf("Failed to decode PEM data")
+		return
+	}
+
+	parsedPublicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Errorf("Failed to parse public key from PEM: %v", err)
+		return
+	}
+
+	ed25519PublicKey, ok := parsedPublicKey.(ed25519.PublicKey)
+	if !ok {
+		t.Errorf("Parsed public key is not ed25519.PublicKey")
+		return
+	}
+
+	// Verify the round-trip preserved the original public key
+	if !ed25519PublicKey.Equal(originalPublicKey) {
+		t.Errorf("Round-trip did not preserve original public key")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * Added support for parsing and validating Ed25519 private keys in both raw and PEM-encoded formats.
  * Enabled extraction of Ed25519 public keys from private keys and output as PEM-encoded files.

* **Tests**
  * Introduced comprehensive tests to ensure correct handling of Ed25519 key parsing, validation, and PEM encoding/decoding, including error scenarios and round-trip conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->