### PR TITLE
OTel: add support for custom dialer

### DIFF
--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -102,12 +102,11 @@ func new(ctx context.Context, oltpServerURL string, authToken string, serviceNam
 	}
 
 	headers := make(map[string]string)
-	if authToken != "" {
-		headers["Authorization"] = "Bearer " + authToken
-	}
-
 	for k, v := range cfg.headers {
 		headers[k] = strings.Join(v, ",")
+	}
+	if authToken != "" {
+		headers["Authorization"] = "Bearer " + authToken
 	}
 
 	// Create HTTP client with custom dialer if provided


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Telemetry init now accepts configuration options for custom timeouts, HTTP headers, and network dialers; public constructors accept these options.

* Improvements
  - Log and trace endpoints use updated paths.
  - Custom headers are merged and multi-value headers are joined for exporters.
  - Custom network client is applied to both logging and tracing exporters.
  - Shutdown timeout now follows configured timeout (+1s); defaults remain 10s/no extra headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->