### PR TITLE
Change otlp.agentuity.com to otel.agentuity.cloud

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -445,7 +445,7 @@ func NewTelemetry(ctx context.Context, cmd *cobra.Command, serviceName string) (
 	if noTelemetry, err := cmd.Flags().GetBool("no-telemetry"); err == nil && noTelemetry {
 		return ctx, NewLogger(cmd), func() {}, nil
 	}
-	otlpURL := FlagOrEnv(cmd, "otlp-url", "AGENTUITY_OTLP_URL", "https://otlp.agentuity.cloud")
+	otlpURL := FlagOrEnv(cmd, "otlp-url", "AGENTUITY_OTLP_URL", "https://otel.agentuity.cloud")
 	otlpSharedSecret := FlagOrEnv(cmd, "otlp-shared-secret", "AGENTUITY_OTLP_SHARED_SECRET", "")
 
 	if otlpURL == "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default telemetry endpoint to https://otel.agentuity.cloud to ensure metrics and traces are sent to the correct destination by default.

* **Chores**
  * Aligned default telemetry configuration with current infrastructure standards.

Notes:
- Existing custom configurations via environment variables or flags are unaffected.
- No changes to public APIs or behavior beyond the default endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->