### PR TITLE
Logger: make sure to pass along base loggers context when using With

### DIFF
--- a/logger/console.go
+++ b/logger/console.go
@@ -142,9 +142,14 @@ func (c *consoleLogger) SetSink(sink Sink, level LogLevel) {
 
 func (c *consoleLogger) With(metadata map[string]interface{}) Logger {
 	clone := c.Clone()
-	for k, v := range metadata {
-		clone.metadata[k] = v
+	merged := make(map[string]interface{})
+	for k, v := range c.metadata {
+		merged[k] = v
 	}
+	for k, v := range metadata {
+		merged[k] = v
+	}
+	clone.metadata = merged
 	if clone.child != nil {
 		clone.child = clone.child.With(metadata)
 	}

--- a/logger/console.go
+++ b/logger/console.go
@@ -142,14 +142,9 @@ func (c *consoleLogger) SetSink(sink Sink, level LogLevel) {
 
 func (c *consoleLogger) With(metadata map[string]interface{}) Logger {
 	clone := c.Clone()
-	merged := make(map[string]interface{})
-	for k, v := range c.metadata {
-		merged[k] = v
-	}
 	for k, v := range metadata {
-		merged[k] = v
+		clone.metadata[k] = v
 	}
-	clone.metadata = merged
 	if clone.child != nil {
 		clone.child = clone.child.With(metadata)
 	}

--- a/logger/console_test.go
+++ b/logger/console_test.go
@@ -146,6 +146,29 @@ func TestConsoleLoggerWithMetadata(t *testing.T) {
 	assert.Contains(t, output, `"key2":"value2"`)
 }
 
+func TestConsoleLoggerWithMergesMetadata(t *testing.T) {
+	logger := NewConsoleLogger().(*consoleLogger)
+
+	baseLogger := logger.With(map[string]interface{}{
+		"base_key": "base_value",
+		"shared":   "from_base",
+	}).(*consoleLogger)
+
+	extendedLogger := baseLogger.With(map[string]interface{}{
+		"extra_key": "extra_value",
+		"shared":    "from_extended",
+	}).(*consoleLogger)
+
+	output := captureOutput(func() {
+		extendedLogger.Info("Test message")
+	})
+
+	assert.Contains(t, output, "Test message")
+	assert.Contains(t, output, `"base_key":"base_value"`)
+	assert.Contains(t, output, `"extra_key":"extra_value"`)
+	assert.Contains(t, output, `"shared":"from_extended"`)
+}
+
 func TestConsoleLoggerSinkTraceLevel(t *testing.T) {
 	logger := NewConsoleLogger().(*consoleLogger)
 	logger.SetLogLevel(LevelTrace)

--- a/logger/json.go
+++ b/logger/json.go
@@ -104,17 +104,22 @@ func (c *jsonLogger) WithPrefix(prefix string) Logger {
 
 func (c *jsonLogger) With(newFields map[string]interface{}) Logger {
 	clone := c.clone()
-	if trace, ok := newFields["trace"].(string); ok {
-		clone.traceID = trace
-		delete(newFields, "trace")
-	}
-	if comp, ok := newFields["component"].(string); ok {
-		clone.component = comp
-		delete(newFields, "component")
+	merged := make(map[string]interface{})
+	for k, v := range c.metadata {
+		merged[k] = v
 	}
 	for k, v := range newFields {
-		clone.metadata[k] = v
+		merged[k] = v
 	}
+	if trace, ok := merged["trace"].(string); ok {
+		clone.traceID = trace
+		delete(merged, "trace")
+	}
+	if comp, ok := merged["component"].(string); ok {
+		clone.component = comp
+		delete(merged, "component")
+	}
+	clone.metadata = merged
 	if c.child != nil {
 		clone.child = c.child.With(newFields)
 	}

--- a/logger/json.go
+++ b/logger/json.go
@@ -104,22 +104,17 @@ func (c *jsonLogger) WithPrefix(prefix string) Logger {
 
 func (c *jsonLogger) With(newFields map[string]interface{}) Logger {
 	clone := c.clone()
-	merged := make(map[string]interface{})
-	for k, v := range c.metadata {
-		merged[k] = v
-	}
 	for k, v := range newFields {
-		merged[k] = v
+		clone.metadata[k] = v
 	}
-	if trace, ok := merged["trace"].(string); ok {
+	if trace, ok := clone.metadata["trace"].(string); ok {
 		clone.traceID = trace
-		delete(merged, "trace")
+		delete(clone.metadata, "trace")
 	}
-	if comp, ok := merged["component"].(string); ok {
+	if comp, ok := clone.metadata["component"].(string); ok {
 		clone.component = comp
-		delete(merged, "component")
+		delete(clone.metadata, "component")
 	}
-	clone.metadata = merged
 	if c.child != nil {
 		clone.child = c.child.With(newFields)
 	}

--- a/logger/otel.go
+++ b/logger/otel.go
@@ -50,6 +50,7 @@ func (o *otelLogger) clone() *otelLogger {
 		logLevel:   o.logLevel,
 		otelLogger: o.otelLogger,
 		child:      o.child,
+		context:    o.context,
 	}
 }
 

--- a/logger/otel.go
+++ b/logger/otel.go
@@ -60,8 +60,14 @@ func toLogValue(unknown interface{}) otelLog.Value {
 		return otelLog.StringValue(v)
 	case int:
 		return otelLog.IntValue(v)
+	case int32:
+		return otelLog.IntValue(int(v))
+	case int64:
+		return otelLog.Int64Value(v)
 	case bool:
 		return otelLog.BoolValue(v)
+	case float32:
+		return otelLog.Float64Value(float64(v))
 	case float64:
 		return otelLog.Float64Value(v)
 	case []byte:
@@ -91,14 +97,9 @@ func toLogValue(unknown interface{}) otelLog.Value {
 // With will return a new logger using metadata as the base context
 func (o *otelLogger) With(metadata map[string]interface{}) Logger {
 	clone := o.clone()
-	merged := make(map[string]otelLog.Value)
-	for k, v := range o.metadata {
-		merged[k] = v
-	}
 	for k, v := range metadata {
-		merged[k] = toLogValue(v)
+		clone.metadata[k] = toLogValue(v)
 	}
-	clone.metadata = merged
 	if clone.child != nil {
 		clone.child = clone.child.With(metadata)
 	}

--- a/logger/otel.go
+++ b/logger/otel.go
@@ -90,9 +90,14 @@ func toLogValue(unknown interface{}) otelLog.Value {
 // With will return a new logger using metadata as the base context
 func (o *otelLogger) With(metadata map[string]interface{}) Logger {
 	clone := o.clone()
-	for k, v := range metadata {
-		clone.metadata[k] = toLogValue(v)
+	merged := make(map[string]otelLog.Value)
+	for k, v := range o.metadata {
+		merged[k] = v
 	}
+	for k, v := range metadata {
+		merged[k] = toLogValue(v)
+	}
+	clone.metadata = merged
 	if clone.child != nil {
 		clone.child = clone.child.With(metadata)
 	}

--- a/logger/otel_test.go
+++ b/logger/otel_test.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/noop"
+)
+
+func TestOtelLoggerWithMergesMetadata(t *testing.T) {
+	noopLogger := noop.NewLoggerProvider().Logger("test")
+
+	logger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: noopLogger,
+		context:    context.Background(),
+	}
+
+	baseLogger := logger.With(map[string]interface{}{
+		"base_key": "base_value",
+		"shared":   "from_base",
+	}).(*otelLogger)
+
+	extendedLogger := baseLogger.With(map[string]interface{}{
+		"extra_key": "extra_value",
+		"shared":    "from_extended",
+	}).(*otelLogger)
+
+	assert.Equal(t, 3, len(extendedLogger.metadata))
+	assert.Equal(t, "base_value", extendedLogger.metadata["base_key"].AsString())
+	assert.Equal(t, "extra_value", extendedLogger.metadata["extra_key"].AsString())
+	assert.Equal(t, "from_extended", extendedLogger.metadata["shared"].AsString())
+}

--- a/logger/otel_test.go
+++ b/logger/otel_test.go
@@ -2,11 +2,16 @@ package logger
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
 	"go.opentelemetry.io/otel/log/noop"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestOtelLoggerWithMergesMetadata(t *testing.T) {
@@ -33,4 +38,195 @@ func TestOtelLoggerWithMergesMetadata(t *testing.T) {
 	assert.Equal(t, "base_value", extendedLogger.metadata["base_key"].AsString())
 	assert.Equal(t, "extra_value", extendedLogger.metadata["extra_key"].AsString())
 	assert.Equal(t, "from_extended", extendedLogger.metadata["shared"].AsString())
+}
+
+type mockOtelLogger struct {
+	embedded.Logger
+	mu       sync.Mutex
+	contexts []context.Context
+}
+
+func (m *mockOtelLogger) Emit(ctx context.Context, record log.Record) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.contexts = append(m.contexts, ctx)
+}
+
+func (m *mockOtelLogger) Enabled(ctx context.Context, param log.EnabledParameters) bool {
+	return true
+}
+
+func (m *mockOtelLogger) getContexts() []context.Context {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]context.Context{}, m.contexts...)
+}
+
+func TestOtelLoggerWithContextPreservesSpanContext(t *testing.T) {
+	mockLogger := &mockOtelLogger{}
+
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test-tracer")
+
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	logger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger,
+		context:    ctx,
+	}
+
+	logger.Info("test message")
+
+	contexts := mockLogger.getContexts()
+	require.Len(t, contexts, 1)
+
+	spanContext := trace.SpanContextFromContext(contexts[0])
+	assert.True(t, spanContext.IsValid())
+	assert.Equal(t, span.SpanContext().TraceID(), spanContext.TraceID())
+	assert.Equal(t, span.SpanContext().SpanID(), spanContext.SpanID())
+}
+
+func TestOtelLoggerWithContextMultipleTimes(t *testing.T) {
+	mockLogger := &mockOtelLogger{}
+
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test-tracer")
+
+	ctx1, span1 := tracer.Start(context.Background(), "span-1")
+	defer span1.End()
+
+	ctx2, span2 := tracer.Start(ctx1, "span-2")
+	defer span2.End()
+
+	ctx3, span3 := tracer.Start(ctx2, "span-3")
+	defer span3.End()
+
+	baseLogger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger,
+		context:    ctx1,
+	}
+
+	logger2 := baseLogger.WithContext(ctx2)
+	logger3 := logger2.WithContext(ctx3)
+
+	logger3.Info("test message")
+
+	contexts := mockLogger.getContexts()
+	require.Len(t, contexts, 1)
+
+	spanContext := trace.SpanContextFromContext(contexts[0])
+	assert.True(t, spanContext.IsValid())
+	assert.Equal(t, span3.SpanContext().TraceID(), spanContext.TraceID())
+	assert.Equal(t, span3.SpanContext().SpanID(), spanContext.SpanID())
+}
+
+func TestOtelLoggerWithContextChainedLoggers(t *testing.T) {
+	mockLogger1 := &mockOtelLogger{}
+	mockLogger2 := &mockOtelLogger{}
+
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test-tracer")
+
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	childLogger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger2,
+		context:    context.Background(),
+	}
+
+	parentLogger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger1,
+		context:    context.Background(),
+		child:      childLogger,
+	}
+
+	loggerWithCtx := parentLogger.WithContext(ctx)
+	loggerWithCtx.Info("test message")
+
+	contexts1 := mockLogger1.getContexts()
+	require.Len(t, contexts1, 1)
+	spanContext1 := trace.SpanContextFromContext(contexts1[0])
+	assert.True(t, spanContext1.IsValid())
+	assert.Equal(t, span.SpanContext().TraceID(), spanContext1.TraceID())
+
+	contexts2 := mockLogger2.getContexts()
+	require.Len(t, contexts2, 1)
+	spanContext2 := trace.SpanContextFromContext(contexts2[0])
+	assert.True(t, spanContext2.IsValid())
+	assert.Equal(t, span.SpanContext().TraceID(), spanContext2.TraceID())
+}
+
+func TestOtelLoggerWithContextPreservesOriginalLogger(t *testing.T) {
+	mockLogger := &mockOtelLogger{}
+
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test-tracer")
+
+	ctx1, span1 := tracer.Start(context.Background(), "span-1")
+	defer span1.End()
+
+	ctx2, span2 := tracer.Start(ctx1, "span-2")
+	defer span2.End()
+
+	baseLogger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger,
+		context:    ctx1,
+	}
+
+	newLogger := baseLogger.WithContext(ctx2)
+
+	baseLogger.Info("original context")
+	newLogger.Info("new context")
+
+	contexts := mockLogger.getContexts()
+	require.Len(t, contexts, 2)
+
+	spanContext1 := trace.SpanContextFromContext(contexts[0])
+	assert.Equal(t, span1.SpanContext().SpanID(), spanContext1.SpanID())
+
+	spanContext2 := trace.SpanContextFromContext(contexts[1])
+	assert.Equal(t, span2.SpanContext().SpanID(), spanContext2.SpanID())
+}
+
+func TestOtelLoggerWithContextAndMetadata(t *testing.T) {
+	mockLogger := &mockOtelLogger{}
+
+	tp := sdktrace.NewTracerProvider()
+	tracer := tp.Tracer("test-tracer")
+
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	baseLogger := &otelLogger{
+		metadata:   make(map[string]log.Value),
+		logLevel:   LevelTrace,
+		otelLogger: mockLogger,
+		context:    context.Background(),
+	}
+
+	loggerWithMetadata := baseLogger.With(map[string]interface{}{
+		"key": "value",
+	})
+
+	loggerWithCtx := loggerWithMetadata.WithContext(ctx)
+	loggerWithCtx.Info("test message")
+
+	contexts := mockLogger.getContexts()
+	require.Len(t, contexts, 1)
+
+	spanContext := trace.SpanContextFromContext(contexts[0])
+	assert.True(t, spanContext.IsValid())
+	assert.Equal(t, span.SpanContext().TraceID(), spanContext.TraceID())
 }

--- a/logger/otel_test.go
+++ b/logger/otel_test.go
@@ -34,6 +34,11 @@ func TestOtelLoggerWithMergesMetadata(t *testing.T) {
 		"shared":    "from_extended",
 	}).(*otelLogger)
 
+	// Verify baseLogger.metadata stayed unchanged (immutability)
+	assert.Equal(t, 2, len(baseLogger.metadata))
+	assert.Equal(t, "base_value", baseLogger.metadata["base_key"].AsString())
+	assert.Equal(t, "from_base", baseLogger.metadata["shared"].AsString())
+
 	assert.Equal(t, 3, len(extendedLogger.metadata))
 	assert.Equal(t, "base_value", extendedLogger.metadata["base_key"].AsString())
 	assert.Equal(t, "extra_value", extendedLogger.metadata["extra_key"].AsString())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry logger now preserves context when cloned.
  * Logs accept int32, int64, and float32 numeric values.

* **Bug Fixes**
  * Correct metadata merging across chained logger contexts for JSON and console outputs.
  * Prevent input metadata mutation and ensure proper extraction/removal of trace/component fields.
  * Ensure overridden metadata keys from child contexts take precedence.

* **Tests**
  * Added tests covering metadata merging, context propagation, and chained logger behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->