### PR TITLE
fix(gravity): add tunnel stream liveness monitor to detect zombie streams

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -873,6 +873,11 @@ func (g *GravityClient) startMultiEndpoint() error {
 		go g.peerDiscoveryLoop()
 	}
 
+	// Monitor tunnel stream liveness. Detects zombie streams where the gRPC
+	// connection is alive (keepalive passes) but data isn't flowing — e.g.,
+	// HTTP/2 flow control deadlock, half-open streams, or stuck Send/Recv.
+	go g.tunnelLivenessMonitor()
+
 	g.logger.Debug("loading CA certificate for TLS...")
 	pool, err := x509.SystemCertPool()
 	if err != nil {
@@ -1098,6 +1103,107 @@ func (g *GravityClient) resolveGravityURLs() []string {
 	}
 
 	return urls
+}
+
+// tunnelLivenessMonitor periodically checks whether tunnel streams are actually
+// carrying data. It detects zombie streams where the gRPC connection is alive
+// (keepalive passes, control stream active) but data has stopped flowing —
+// caused by HTTP/2 flow control deadlock, half-open streams, or stuck Send/Recv.
+//
+// If ANY stream on an endpoint has no send AND no receive activity for 60s,
+// the endpoint is marked unhealthy and reconnection is triggered. This is the
+// data-plane complement to the control-plane gRPC keepalive.
+func (g *GravityClient) tunnelLivenessMonitor() {
+	const (
+		checkInterval = 15 * time.Second
+		staleTimeout  = 60 * time.Second
+	)
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+		case <-ticker.C:
+			g.checkTunnelStreamLiveness(staleTimeout)
+		}
+	}
+}
+
+// checkTunnelStreamLiveness examines each tunnel stream's last activity
+// timestamps and triggers reconnection for endpoints with all-stale streams.
+func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
+	now := time.Now().UnixMicro()
+	staleUs := staleTimeout.Microseconds()
+
+	g.streamManager.tunnelMu.RLock()
+	streams := g.streamManager.tunnelStreams
+	g.streamManager.tunnelMu.RUnlock()
+
+	if len(streams) == 0 {
+		return
+	}
+
+	// Determine streams per connection from the pool config
+	streamsPerConn := g.poolConfig.StreamsPerGravity
+	if streamsPerConn <= 0 {
+		streamsPerConn = DefaultStreamsPerGravity
+	}
+
+	g.streamManager.metricsMu.RLock()
+	defer g.streamManager.metricsMu.RUnlock()
+
+	// Check each endpoint's streams as a group
+	for connIndex := 0; connIndex*streamsPerConn < len(streams); connIndex++ {
+		base := connIndex * streamsPerConn
+		end := base + streamsPerConn
+		if end > len(streams) {
+			end = len(streams)
+		}
+
+		allStale := true
+		hasStreams := false
+		for i := base; i < end; i++ {
+			si := streams[i]
+			if si == nil || !si.isHealthy {
+				continue
+			}
+			hasStreams = true
+
+			metrics, ok := g.streamManager.streamMetrics[si.streamID]
+			if !ok {
+				continue
+			}
+
+			lastActivity := metrics.LastSendUs
+			if metrics.LastRecvUs > lastActivity {
+				lastActivity = metrics.LastRecvUs
+			}
+
+			if lastActivity > 0 && (now-lastActivity) < staleUs {
+				allStale = false
+				break
+			}
+		}
+
+		if hasStreams && allStale {
+			g.endpointsMu.RLock()
+			var epURL string
+			if connIndex < len(g.endpoints) && g.endpoints[connIndex] != nil {
+				epURL = g.endpoints[connIndex].URL
+				g.endpoints[connIndex].healthy.Store(false)
+			}
+			g.endpointsMu.RUnlock()
+
+			g.logger.Warn("tunnel liveness: endpoint %d (%s) has all stale streams (no activity for %s) — triggering reconnection",
+				connIndex, epURL, staleTimeout)
+			g.wakePeerDiscovery()
+			g.triggerAllEndpointReconnections("tunnel_liveness_stale")
+			return // One reconnection cycle at a time
+		}
+	}
 }
 
 func (g *GravityClient) bindingCleanupLoop() {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -721,6 +721,8 @@ func (g *GravityClient) Start() error {
 	g.connected = true
 	g.mu.Unlock()
 
+	go g.tunnelLivenessMonitor()
+
 	g.logger.Debug("connected to Gravity server: %s", g.url)
 
 	g.logger.Debug("starting background goroutines...")
@@ -889,11 +891,6 @@ func (g *GravityClient) startMultiEndpoint() error {
 		go g.peerDiscoveryLoop()
 	}
 
-	// Monitor tunnel stream liveness. Detects zombie streams where the gRPC
-	// connection is alive (keepalive passes) but data isn't flowing — e.g.,
-	// HTTP/2 flow control deadlock, half-open streams, or stuck Send/Recv.
-	go g.tunnelLivenessMonitor()
-
 	g.logger.Debug("loading CA certificate for TLS...")
 	pool, err := x509.SystemCertPool()
 	if err != nil {
@@ -1051,6 +1048,10 @@ func (g *GravityClient) startMultiEndpoint() error {
 	g.connected = true
 	g.mu.Unlock()
 
+	// Start tunnel liveness monitor after startup succeeds (connected=true).
+	// Starting earlier would leak the goroutine if startup fails.
+	go g.tunnelLivenessMonitor()
+
 	var endpointURLs []string
 	for _, ep := range endpoints {
 		endpointURLs = append(endpointURLs, ep.URL)
@@ -1165,6 +1166,7 @@ type streamSnapshot struct {
 	connIndex int
 	isHealthy bool
 	stream    pb.GravitySessionService_StreamSessionPacketsClient
+	sendMu    *sync.Mutex // pointer to the stream's send mutex for serialization
 }
 
 func (g *GravityClient) sendTunnelKeepalives() {
@@ -1178,6 +1180,7 @@ func (g *GravityClient) sendTunnelKeepalives() {
 				connIndex: si.connIndex,
 				isHealthy: si.isHealthy,
 				stream:    si.stream,
+				sendMu:    &si.sendMu,
 			}
 		}
 	}
@@ -1215,12 +1218,25 @@ func (g *GravityClient) sendTunnelKeepalives() {
 
 		for i := base; i < end; i++ {
 			s := snapshots[i]
-			if !s.isHealthy || s.stream == nil {
+			if !s.isHealthy || s.stream == nil || s.sendMu == nil {
 				continue
 			}
-			if err := s.stream.Send(&pb.TunnelPacket{Data: probe}); err != nil {
-				g.logger.Debug("tunnel keepalive send failed on stream %d: %v", i, err)
-			}
+			// Serialize with the data path's sendMu. Use a goroutine with
+			// timeout so a wedged Send doesn't block the monitor loop.
+			go func(idx int, snap streamSnapshot) {
+				done := make(chan struct{})
+				go func() {
+					snap.sendMu.Lock()
+					_ = snap.stream.Send(&pb.TunnelPacket{Data: probe})
+					snap.sendMu.Unlock()
+					close(done)
+				}()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+					g.logger.Warn("tunnel keepalive send blocked >5s on stream %d — possible zombie", idx)
+				}
+			}(i, s)
 			break // one probe per endpoint is enough
 		}
 	}

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -95,7 +95,7 @@ const (
 // immediately without writing to the TUN. This provides a positive data-plane
 // liveness signal on each tunnel stream, detecting zombie streams and keeping
 // idle connections active.
-var TunnelKeepaliveMarker = []byte{0x47, 0x4B, 0x45, 0x50} // "GKEP"
+var TunnelKeepaliveMarker = []byte{0x41, 0x47, 0x4E, 0x54} // "AGNT"
 
 // IsTunnelKeepalive checks if a packet is a tunnel keepalive probe.
 func IsTunnelKeepalive(data []byte) bool {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1158,12 +1158,32 @@ func (g *GravityClient) tunnelLivenessMonitor() {
 // endpoint. Ion echoes the probe back, updating both send and receive
 // timestamps. This keeps idle streams active and detects zombie streams
 // that can't round-trip data.
+// streamSnapshot holds fields copied from StreamInfo under tunnelMu for
+// safe access outside the lock.
+type streamSnapshot struct {
+	streamID  string
+	connIndex int
+	isHealthy bool
+	stream    pb.GravitySessionService_StreamSessionPacketsClient
+}
+
 func (g *GravityClient) sendTunnelKeepalives() {
+	// Snapshot stream info under tunnelMu to avoid data races on isHealthy.
 	g.streamManager.tunnelMu.RLock()
-	streams := g.streamManager.tunnelStreams
+	snapshots := make([]streamSnapshot, len(g.streamManager.tunnelStreams))
+	for i, si := range g.streamManager.tunnelStreams {
+		if si != nil {
+			snapshots[i] = streamSnapshot{
+				streamID:  si.streamID,
+				connIndex: si.connIndex,
+				isHealthy: si.isHealthy,
+				stream:    si.stream,
+			}
+		}
+	}
 	g.streamManager.tunnelMu.RUnlock()
 
-	if len(streams) == 0 {
+	if len(snapshots) == 0 {
 		return
 	}
 
@@ -1186,19 +1206,19 @@ func (g *GravityClient) sendTunnelKeepalives() {
 	probe[11] = byte(ts)
 
 	// Send on one stream per endpoint
-	for connIndex := 0; connIndex*streamsPerConn < len(streams); connIndex++ {
+	for connIndex := 0; connIndex*streamsPerConn < len(snapshots); connIndex++ {
 		base := connIndex * streamsPerConn
 		end := base + streamsPerConn
-		if end > len(streams) {
-			end = len(streams)
+		if end > len(snapshots) {
+			end = len(snapshots)
 		}
 
 		for i := base; i < end; i++ {
-			si := streams[i]
-			if si == nil || !si.isHealthy || si.stream == nil {
+			s := snapshots[i]
+			if !s.isHealthy || s.stream == nil {
 				continue
 			}
-			if err := si.stream.Send(&pb.TunnelPacket{Data: probe}); err != nil {
+			if err := s.stream.Send(&pb.TunnelPacket{Data: probe}); err != nil {
 				g.logger.Debug("tunnel keepalive send failed on stream %d: %v", i, err)
 			}
 			break // one probe per endpoint is enough
@@ -1212,11 +1232,21 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 	now := time.Now().UnixMicro()
 	staleUs := staleTimeout.Microseconds()
 
+	// Snapshot stream info under tunnelMu to avoid data races on isHealthy/streamID.
 	g.streamManager.tunnelMu.RLock()
-	streams := g.streamManager.tunnelStreams
+	snapshots := make([]streamSnapshot, len(g.streamManager.tunnelStreams))
+	for i, si := range g.streamManager.tunnelStreams {
+		if si != nil {
+			snapshots[i] = streamSnapshot{
+				streamID:  si.streamID,
+				connIndex: si.connIndex,
+				isHealthy: si.isHealthy,
+			}
+		}
+	}
 	g.streamManager.tunnelMu.RUnlock()
 
-	if len(streams) == 0 {
+	if len(snapshots) == 0 {
 		return
 	}
 
@@ -1230,23 +1260,23 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 	defer g.streamManager.metricsMu.RUnlock()
 
 	// Check each endpoint's streams as a group
-	for connIndex := 0; connIndex*streamsPerConn < len(streams); connIndex++ {
+	for connIndex := 0; connIndex*streamsPerConn < len(snapshots); connIndex++ {
 		base := connIndex * streamsPerConn
 		end := base + streamsPerConn
-		if end > len(streams) {
-			end = len(streams)
+		if end > len(snapshots) {
+			end = len(snapshots)
 		}
 
 		allStale := true
 		hasStreams := false
 		for i := base; i < end; i++ {
-			si := streams[i]
-			if si == nil || !si.isHealthy {
+			s := snapshots[i]
+			if !s.isHealthy {
 				continue
 			}
 			hasStreams = true
 
-			metrics, ok := g.streamManager.streamMetrics[si.streamID]
+			metrics, ok := g.streamManager.streamMetrics[s.streamID]
 			if !ok {
 				continue
 			}

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -90,6 +90,22 @@ const (
 	DefaultBindingTTL = 10 * time.Minute
 )
 
+// TunnelKeepaliveMarker is a 4-byte magic prefix for tunnel keepalive packets.
+// When ion receives a packet starting with this marker, it echoes it back
+// immediately without writing to the TUN. This provides a positive data-plane
+// liveness signal on each tunnel stream, detecting zombie streams and keeping
+// idle connections active.
+var TunnelKeepaliveMarker = []byte{0x47, 0x4B, 0x45, 0x50} // "GKEP"
+
+// IsTunnelKeepalive checks if a packet is a tunnel keepalive probe.
+func IsTunnelKeepalive(data []byte) bool {
+	return len(data) >= 4 &&
+		data[0] == TunnelKeepaliveMarker[0] &&
+		data[1] == TunnelKeepaliveMarker[1] &&
+		data[2] == TunnelKeepaliveMarker[2] &&
+		data[3] == TunnelKeepaliveMarker[3]
+}
+
 // isContextCanceled checks if an error is due to context cancellation
 // This includes both direct context.Canceled errors and gRPC Canceled status codes
 func isContextCanceled(ctx context.Context, err error) bool {
@@ -1105,14 +1121,19 @@ func (g *GravityClient) resolveGravityURLs() []string {
 	return urls
 }
 
-// tunnelLivenessMonitor periodically checks whether tunnel streams are actually
-// carrying data. It detects zombie streams where the gRPC connection is alive
-// (keepalive passes, control stream active) but data has stopped flowing —
-// caused by HTTP/2 flow control deadlock, half-open streams, or stuck Send/Recv.
+// tunnelLivenessMonitor periodically sends keepalive probes on tunnel streams
+// and checks whether they're actually carrying data. It detects zombie streams
+// where the gRPC connection is alive (keepalive passes, control stream active)
+// but data has stopped flowing — caused by HTTP/2 flow control deadlock,
+// half-open streams, or stuck Send/Recv.
 //
-// If ANY stream on an endpoint has no send AND no receive activity for 60s,
-// the endpoint is marked unhealthy and reconnection is triggered. This is the
-// data-plane complement to the control-plane gRPC keepalive.
+// The keepalive probe ("GKEP" marker) is sent on one stream per endpoint every
+// 15s. Ion echoes it back immediately, updating both LastSendUs and LastRecvUs.
+// This keeps idle connections active and provides a positive liveness signal.
+//
+// If ALL streams on an endpoint have had activity (non-zero timestamps) but
+// no activity for 60s, the endpoint is marked unhealthy and reconnection is
+// triggered. Streams that have never carried data (idle) are not flagged.
 func (g *GravityClient) tunnelLivenessMonitor() {
 	const (
 		checkInterval = 15 * time.Second
@@ -1127,7 +1148,60 @@ func (g *GravityClient) tunnelLivenessMonitor() {
 		case <-g.ctx.Done():
 			return
 		case <-ticker.C:
+			g.sendTunnelKeepalives()
 			g.checkTunnelStreamLiveness(staleTimeout)
+		}
+	}
+}
+
+// sendTunnelKeepalives sends a keepalive probe on one healthy stream per
+// endpoint. Ion echoes the probe back, updating both send and receive
+// timestamps. This keeps idle streams active and detects zombie streams
+// that can't round-trip data.
+func (g *GravityClient) sendTunnelKeepalives() {
+	g.streamManager.tunnelMu.RLock()
+	streams := g.streamManager.tunnelStreams
+	g.streamManager.tunnelMu.RUnlock()
+
+	if len(streams) == 0 {
+		return
+	}
+
+	streamsPerConn := g.poolConfig.StreamsPerGravity
+	if streamsPerConn <= 0 {
+		streamsPerConn = DefaultStreamsPerGravity
+	}
+
+	// Build keepalive packet: 4-byte marker + 8-byte timestamp (for RTT measurement)
+	probe := make([]byte, 12)
+	copy(probe, TunnelKeepaliveMarker)
+	ts := time.Now().UnixMicro()
+	probe[4] = byte(ts >> 56)
+	probe[5] = byte(ts >> 48)
+	probe[6] = byte(ts >> 40)
+	probe[7] = byte(ts >> 32)
+	probe[8] = byte(ts >> 24)
+	probe[9] = byte(ts >> 16)
+	probe[10] = byte(ts >> 8)
+	probe[11] = byte(ts)
+
+	// Send on one stream per endpoint
+	for connIndex := 0; connIndex*streamsPerConn < len(streams); connIndex++ {
+		base := connIndex * streamsPerConn
+		end := base + streamsPerConn
+		if end > len(streams) {
+			end = len(streams)
+		}
+
+		for i := base; i < end; i++ {
+			si := streams[i]
+			if si == nil || !si.isHealthy || si.stream == nil {
+				continue
+			}
+			if err := si.stream.Send(&pb.TunnelPacket{Data: probe}); err != nil {
+				g.logger.Debug("tunnel keepalive send failed on stream %d: %v", i, err)
+			}
+			break // one probe per endpoint is enough
 		}
 	}
 }
@@ -1182,8 +1256,17 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 				lastActivity = metrics.LastRecvUs
 			}
 
-			if lastActivity > 0 && (now-lastActivity) < staleUs {
-				allStale = false
+			// If the stream has never carried data (both timestamps 0),
+			// it's idle — not stale. Only flag as stale if the stream
+			// WAS active (had traffic) and then stopped. This prevents
+			// a reconnection loop on idle hadrons with no containers.
+			if lastActivity == 0 {
+				allStale = false // idle, not stale
+				break
+			}
+
+			if (now - lastActivity) < staleUs {
+				allStale = false // recently active
 				break
 			}
 		}
@@ -2119,6 +2202,13 @@ func (g *GravityClient) handleTunnelStream(streamIndex int, stream pb.GravitySes
 			metrics.BytesReceived += int64(len(packet.Data))
 		}
 		g.streamManager.metricsMu.Unlock()
+
+		// Handle tunnel keepalive echo — don't forward to TUN.
+		// The probe was sent by sendTunnelKeepalives() and echoed by ion.
+		// Receiving it proves the tunnel stream round-trips data.
+		if IsTunnelKeepalive(packet.Data) {
+			continue
+		}
 
 		// Forward packet to local processing
 		pooledBuf := g.getBuffer(packet.Data)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1132,7 +1132,7 @@ func (g *GravityClient) resolveGravityURLs() []string {
 // but data has stopped flowing — caused by HTTP/2 flow control deadlock,
 // half-open streams, or stuck Send/Recv.
 //
-// The keepalive probe ("GKEP" marker) is sent on one stream per endpoint every
+// The keepalive probe ("AGNT" marker) is sent on one stream per endpoint every
 // 15s. Ion echoes it back immediately, updating both LastSendUs and LastRecvUs.
 // This keeps idle connections active and provides a positive liveness signal.
 //

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -244,6 +244,10 @@ type GravityClient struct {
 	// Overridable in tests.
 	dnsLookupMulti func(ctx context.Context, hostname string) (bool, []net.IP, error)
 
+	// probeRotation tracks which stream within each endpoint to probe next.
+	// Incremented each cycle so all streams are covered within the stale timeout.
+	probeRotation atomic.Int64
+
 	// healthProbe is the function used to check if a gravity endpoint is
 	// alive before connecting. Defaults to probeHealthEndpoint (HTTP probe).
 	// Overridable in tests to avoid real network calls.
@@ -1208,7 +1212,11 @@ func (g *GravityClient) sendTunnelKeepalives() {
 	probe[10] = byte(ts >> 8)
 	probe[11] = byte(ts)
 
-	// Send on one stream per endpoint
+	// Rotate which stream gets probed within each endpoint. Each cycle probes
+	// a different stream so all streams are covered within the stale timeout
+	// (60s / 15s interval = 4 cycles → covers all 4 streams per endpoint).
+	rotation := int(g.probeRotation.Add(1))
+
 	for connIndex := 0; connIndex*streamsPerConn < len(snapshots); connIndex++ {
 		base := connIndex * streamsPerConn
 		end := base + streamsPerConn
@@ -1216,29 +1224,38 @@ func (g *GravityClient) sendTunnelKeepalives() {
 			end = len(snapshots)
 		}
 
+		// Count healthy streams for this endpoint to pick the rotation target
+		healthyInEndpoint := make([]int, 0, streamsPerConn)
 		for i := base; i < end; i++ {
 			s := snapshots[i]
-			if !s.isHealthy || s.stream == nil || s.sendMu == nil {
-				continue
+			if s.isHealthy && s.stream != nil && s.sendMu != nil {
+				healthyInEndpoint = append(healthyInEndpoint, i)
 			}
-			// Serialize with the data path's sendMu. Use a goroutine with
-			// timeout so a wedged Send doesn't block the monitor loop.
-			go func(idx int, snap streamSnapshot) {
-				done := make(chan struct{})
-				go func() {
-					snap.sendMu.Lock()
-					_ = snap.stream.Send(&pb.TunnelPacket{Data: probe})
-					snap.sendMu.Unlock()
-					close(done)
-				}()
-				select {
-				case <-done:
-				case <-time.After(5 * time.Second):
-					g.logger.Warn("tunnel keepalive send blocked >5s on stream %d — possible zombie", idx)
-				}
-			}(i, s)
-			break // one probe per endpoint is enough
 		}
+		if len(healthyInEndpoint) == 0 {
+			continue
+		}
+
+		// Pick the stream for this rotation cycle
+		targetIdx := healthyInEndpoint[rotation%len(healthyInEndpoint)]
+		s := snapshots[targetIdx]
+
+		// Serialize with the data path's sendMu. Use a goroutine with
+		// timeout so a wedged Send doesn't block the monitor loop.
+		go func(idx int, snap streamSnapshot) {
+			done := make(chan struct{})
+			go func() {
+				snap.sendMu.Lock()
+				_ = snap.stream.Send(&pb.TunnelPacket{Data: probe})
+				snap.sendMu.Unlock()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				g.logger.Warn("tunnel keepalive send blocked >5s on stream %d — possible zombie", idx)
+			}
+		}(targetIdx, s)
 	}
 }
 


### PR DESCRIPTION
## Summary
Add a data-plane liveness monitor that detects zombie tunnel streams — where the gRPC connection is alive but data has stopped flowing.

## Problem
After an ion rollout, hadron reconnects and reports "3/3 healthy at capacity", but actual data doesn't flow through some tunnel streams. The proxy dials through the overlay, SYN enters the TUN, but never reaches hadron → 504 Gateway Timeout.

Root cause: the tunnel streams are in a zombie state — the gRPC connection is TCP-alive (keepalive pings succeed), the control stream is active, but the data streams are stuck (HTTP/2 flow control deadlock, half-open state, or stuck Send/Recv).

**Existing detection mechanisms and their gaps:**
- gRPC keepalive (30s ping, 10s timeout) → detects dead TCP connections ✅, but NOT flow-control deadlocks ❌
- `helloAckedStreams` → prevents orphaned streams ✅, but NOT streams that die after establishment ❌
- `consecutiveWriteFailures` → triggers reconnection on write failures ✅, but NOT when writes succeed but data doesn't arrive ❌

## Fix
Background goroutine `tunnelLivenessMonitor` runs every 15s and checks `LastSendUs`/`LastRecvUs` on each stream via `StreamMetrics`. If ALL streams on an endpoint have no activity for 60s:
1. Mark endpoint unhealthy
2. Wake peer discovery
3. Trigger reconnection for all endpoints

**Detection timeline:** zombie detected within 60-75s (vs never before).

## How it works
```
Normal operation:
  stream.Send() → updates LastSendUs
  stream.Recv() → updates LastRecvUs
  Monitor checks every 15s → activity recent → healthy ✅

Zombie state:
  stream.Send() blocks (HTTP/2 flow control)
  stream.Recv() blocks (no data from ion)
  Monitor checks → LastSendUs/LastRecvUs stale >60s → UNHEALTHY
  → mark unhealthy → wake discovery → reconnect → fresh streams ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous background monitoring of tunnel data-plane liveness with periodic keepalive probes; sends one probe per endpoint group and detects stale tunnel streams to trigger reconnections.
  * Idle-suppression avoids treating never-used streams as stale, preventing unnecessary reconnections.

* **Bug Fixes**
  * Keepalive probe packets are intercepted and not forwarded to the local packet path, avoiding interference with user traffic while still updating tunnel metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->