### PR TITLE
fix(gravity): prevent cascading endpoint reconnection and improve multi-HA resilience

### DIFF
--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -2,6 +2,7 @@ package gravity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -878,4 +879,1664 @@ func TestTriggerEndpointReconnectByURL_UnknownURL(t *testing.T) {
 	// Should not panic
 	g.triggerEndpointReconnectByURL("grpc://nonexistent")
 	time.Sleep(50 * time.Millisecond)
+}
+
+// --- Aggressive reconnection isolation tests ---
+//
+// These tests verify that triggerAllEndpointReconnections does NOT cascade
+// a single-endpoint failure to healthy endpoints. This was the root cause of
+// a production outage: when one ion died, the aggressive reconnect killed
+// the healthy ion's streams too, causing total connectivity loss.
+
+// TestTriggerAllEndpointReconnections_SkipsHealthyEndpoints verifies that
+// when triggerAllEndpointReconnections is called, endpoints that are still
+// healthy are NOT reconnected. Only unhealthy endpoints should be targeted.
+func TestTriggerAllEndpointReconnections_SkipsHealthyEndpoints(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 3)
+	g.gravityURLs = []string{"a", "b", "c"}
+
+	// Set up control streams and tunnel streams for all 3 endpoints.
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "t0"},
+		{connIndex: 1, isHealthy: true, streamID: "t1"},
+		{connIndex: 2, isHealthy: true, streamID: "t2"},
+	}
+
+	// Endpoint 0 is unhealthy (its ion died). Endpoints 1 and 2 are healthy.
+	g.endpoints[0].healthy.Store(false)
+	// endpoints 1 and 2 remain healthy (set by newEndpointTestClient)
+
+	g.triggerAllEndpointReconnections("test_single_endpoint_failure")
+
+	// Give reconnection goroutines a moment to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// CRITICAL ASSERTION: Only the unhealthy endpoint should be reconnecting.
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected unhealthy endpoint 0 to enter reconnection")
+	}
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected healthy endpoint 1 to NOT enter reconnection — cascading failure!")
+	}
+	if g.endpointReconnecting[2].Load() {
+		t.Fatal("expected healthy endpoint 2 to NOT enter reconnection — cascading failure!")
+	}
+
+	// Healthy endpoints' control streams must remain intact.
+	g.streamManager.controlMu.RLock()
+	cs1 := g.streamManager.controlStreams[1]
+	cs2 := g.streamManager.controlStreams[2]
+	g.streamManager.controlMu.RUnlock()
+	if cs1 == nil {
+		t.Fatal("expected healthy endpoint 1 control stream to remain intact")
+	}
+	if cs2 == nil {
+		t.Fatal("expected healthy endpoint 2 control stream to remain intact")
+	}
+
+	// Healthy endpoints' tunnel streams must remain healthy.
+	g.streamManager.tunnelMu.RLock()
+	for _, s := range g.streamManager.tunnelStreams {
+		if s.connIndex != 0 && !s.isHealthy {
+			t.Fatalf("expected healthy endpoint %d tunnel stream to remain healthy", s.connIndex)
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
+	// Healthy endpoints' health flags must not be touched.
+	if !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected endpoint 1 to remain healthy")
+	}
+	if !g.endpoints[2].IsHealthy() {
+		t.Fatal("expected endpoint 2 to remain healthy")
+	}
+}
+
+// TestTriggerAllEndpointReconnections_AllUnhealthy_ReconnectsAll verifies that
+// when ALL endpoints are unhealthy, triggerAllEndpointReconnections does not
+// skip them (the healthy-endpoint safety net only protects truly healthy ones).
+//
+// We cancel the context before calling triggerAll so the reconnect goroutines
+// exit immediately, then verify via the synchronous side effects of
+// disconnectEndpointStreams (called before each goroutine starts).
+func TestTriggerAllEndpointReconnections_AllUnhealthy_ReconnectsAll(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	g := &GravityClient{
+		logger:                logger.NewTestLogger(),
+		ctx:                   ctx,
+		cancel:                cancel,
+		retryConfig:           DefaultRetryConfig(),
+		connections:           make([]*grpc.ClientConn, 3),
+		sessionClients:        make([]pb.GravitySessionServiceClient, 3),
+		connectionURLs:        []string{"grpc://ep-0", "grpc://ep-1", "grpc://ep-2"},
+		endpoints:             make([]*GravityEndpoint, 3),
+		endpointReconnecting:  make([]atomic.Bool, 3),
+		circuitBreakers:       make([]*CircuitBreaker, 3),
+		connectionIDChan:      make(chan string, 16),
+		endpointStreamIndices: make(map[string][]int),
+		closed:                make(chan struct{}, 1),
+		streamManager: &StreamManager{
+			controlStreams:   make([]pb.GravitySessionService_EstablishSessionClient, 3),
+			controlSendMu:    make([]sync.Mutex, 3),
+			tunnelStreams:    make([]*StreamInfo, 0),
+			connectionHealth: make([]bool, 3),
+			streamMetrics:    make(map[string]*StreamMetrics),
+			contexts:         make([]context.Context, 3),
+			cancels:          make([]context.CancelFunc, 3),
+		},
+	}
+	for i := 0; i < 3; i++ {
+		ep := &GravityEndpoint{URL: g.connectionURLs[i]}
+		ep.healthy.Store(false) // ALL unhealthy
+		g.endpoints[i] = ep
+		g.streamManager.connectionHealth[i] = false // consistent with unhealthy endpoints
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+		g.circuitBreakers[i] = NewCircuitBreaker(DefaultCircuitBreakerConfig())
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "t0"},
+		{connIndex: 1, isHealthy: true, streamID: "t1"},
+		{connIndex: 2, isHealthy: true, streamID: "t2"},
+	}
+	g.multiEndpointMode.Store(true)
+
+	// Cancel context so reconnect goroutines exit immediately via
+	// g.ctx.Done(), preventing the defer from racing with our assertions.
+	cancel()
+
+	g.triggerAllEndpointReconnections("all_endpoints_down")
+
+	// Give goroutines a moment to start and exit.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify disconnectEndpointStreams was called for ALL endpoints
+	// (synchronous side effect: control streams nil'd before goroutine).
+	g.streamManager.controlMu.RLock()
+	for i, cs := range g.streamManager.controlStreams {
+		if cs != nil {
+			t.Fatalf("expected control stream %d to be nil (disconnected) for unhealthy endpoint", i)
+		}
+	}
+	g.streamManager.controlMu.RUnlock()
+
+	g.streamManager.tunnelMu.RLock()
+	for _, s := range g.streamManager.tunnelStreams {
+		if s.isHealthy {
+			t.Fatalf("expected tunnel stream %s (endpoint %d) to be marked unhealthy", s.streamID, s.connIndex)
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
+	for i := 0; i < 3; i++ {
+		if g.streamManager.connectionHealth[i] {
+			t.Fatalf("expected connectionHealth[%d]=false for unhealthy endpoint", i)
+		}
+	}
+}
+
+// TestTriggerAllEndpointReconnections_AllHealthy_ReconnectsNone verifies the
+// safety-net: even if triggerAllEndpointReconnections is called erroneously,
+// healthy endpoints are protected.
+func TestTriggerAllEndpointReconnections_AllHealthy_ReconnectsNone(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 3)
+	g.gravityURLs = []string{"a", "b", "c"}
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "t0"},
+		{connIndex: 1, isHealthy: true, streamID: "t1"},
+		{connIndex: 2, isHealthy: true, streamID: "t2"},
+	}
+
+	// All endpoints are healthy — this call should be a no-op.
+	g.triggerAllEndpointReconnections("erroneous_call")
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		if g.endpointReconnecting[i].Load() {
+			t.Fatalf("expected healthy endpoint %d to NOT enter reconnection", i)
+		}
+	}
+
+	// All streams must remain intact.
+	g.streamManager.controlMu.RLock()
+	for i, cs := range g.streamManager.controlStreams {
+		if cs == nil {
+			t.Fatalf("expected control stream %d to remain intact", i)
+		}
+	}
+	g.streamManager.controlMu.RUnlock()
+}
+
+// TestCascadingFailurePrevention_SingleEndpointDeath is an end-to-end scenario
+// test that reproduces the exact production bug: one ion dies, its streams
+// fail, consecutive write failures trigger aggressive reconnect, and the
+// healthy ion's streams must survive.
+func TestCascadingFailurePrevention_SingleEndpointDeath(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+
+	// Full stream setup for both endpoints.
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0"},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1"},
+	}
+
+	// Simulate: ion 0 dies. Its endpoint is marked unhealthy by health checks.
+	g.endpoints[0].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+
+	// The write failure path triggers aggressive reconnect.
+	g.triggerAllEndpointReconnections("consecutive_write_failures")
+	time.Sleep(100 * time.Millisecond)
+
+	// Endpoint 0 (dead ion) should be reconnecting.
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected dead endpoint 0 to enter reconnection")
+	}
+
+	// CRITICAL: Endpoint 1 (healthy ion) must NOT be reconnecting.
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("CASCADING FAILURE: healthy endpoint 1 was killed by aggressive reconnect of dead endpoint 0")
+	}
+
+	// Endpoint 1's streams must be fully intact.
+	g.streamManager.controlMu.RLock()
+	if g.streamManager.controlStreams[1] == nil {
+		t.Fatal("CASCADING FAILURE: healthy endpoint 1 control stream was destroyed")
+	}
+	g.streamManager.controlMu.RUnlock()
+
+	g.streamManager.tunnelMu.RLock()
+	for _, s := range g.streamManager.tunnelStreams {
+		if s.connIndex == 1 && !s.isHealthy {
+			t.Fatal("CASCADING FAILURE: healthy endpoint 1 tunnel stream was marked unhealthy")
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
+	if !g.endpoints[1].IsHealthy() {
+		t.Fatal("CASCADING FAILURE: healthy endpoint 1 was marked unhealthy")
+	}
+
+	// The system should still have a healthy endpoint for traffic.
+	if !g.hasHealthyEndpoint() {
+		t.Fatal("CASCADING FAILURE: no healthy endpoints remain — total outage")
+	}
+}
+
+// ============================================================================
+// WritePacket Integration Tests & Additional Coverage
+// ============================================================================
+
+// newWritePacketTestClient creates a GravityClient configured for WritePacket
+// integration tests: connected=true, multi-endpoint mode, selector, pool config,
+// and buffer pool. Tests must still set up tunnel streams and endpointStreamIndices.
+func newWritePacketTestClient(t *testing.T, n int) *GravityClient {
+	t.Helper()
+	g := newHardeningGravityClient(t, n)
+	g.multiEndpointMode.Store(n > 1)
+	g.selector = NewEndpointSelector(5 * time.Second)
+	g.peerDiscoveryWake = make(chan struct{}, 1) // prevent nil channel panic
+	g.streamManager.allocationStrategy = RoundRobin
+	return g
+}
+
+// makeIPv6Packet creates a minimal 44-byte IPv6 packet with TCP next header.
+// Bytes 0: version nibble (0x60), byte 6: next header (TCP=6), bytes 8-23: src IP,
+// bytes 24-39: dst IP, bytes 40-43: src/dst ports.
+func makeIPv6Packet() []byte {
+	pkt := make([]byte, 54)
+	pkt[0] = 0x60 // IPv6 version nibble
+	pkt[6] = 6    // TCP next header
+	pkt[8] = 0xfd // src IP starts with fd00::
+	pkt[9] = 0x00
+	pkt[23] = 1    // src IP: fd00::1
+	pkt[24] = 0xfd // dst IP starts with fd00::
+	pkt[25] = 0x00
+	pkt[39] = 2    // dst IP: fd00::2
+	pkt[40] = 0x00 // src port high byte
+	pkt[41] = 0x50 // src port = 80
+	pkt[42] = 0x01 // dst port high byte
+	pkt[43] = 0xBB // dst port = 443
+	return pkt
+}
+
+// setupWritePacketStreams creates mock tunnel streams and wires up
+// endpointStreamIndices and streamMetrics for WritePacket integration tests.
+func setupWritePacketStreams(g *GravityClient, streams []*StreamInfo) {
+	g.streamManager.tunnelStreams = streams
+	g.endpointStreamIndices = make(map[string][]int)
+	for idx, s := range streams {
+		if s == nil {
+			continue
+		}
+		url := g.connectionURLs[s.connIndex]
+		g.endpointStreamIndices[url] = append(g.endpointStreamIndices[url], idx)
+	}
+	for _, s := range streams {
+		if s == nil {
+			continue
+		}
+		g.streamManager.streamMetrics[s.streamID] = &StreamMetrics{}
+	}
+}
+
+// preBindFlowToEndpoint creates a flow binding from the given packet to the
+// specified endpoint index. This forces selectStreamForPacket to try that
+// endpoint first.
+func preBindFlowToEndpoint(g *GravityClient, pkt []byte, epIdx int) {
+	key := ExtractFlowKey(pkt)
+	g.selector.mu.Lock()
+	g.selector.bindings[key] = &TunnelBinding{
+		Endpoint: g.endpoints[epIdx],
+		LastUsed: time.Now(),
+	}
+	g.selector.mu.Unlock()
+}
+
+// --- Category A: Integration Tests Through WritePacket ---
+
+// TestWritePacket_SendFailure_DoesNotTriggerReconnection verifies that a
+// tunnel Send() error in WritePacket does NOT trigger endpoint reconnection.
+// The stream is marked unhealthy but no aggressive reconnection is started.
+func TestWritePacket_SendFailure_DoesNotTriggerReconnection(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	// ep0 has broken tunnel streams, ep1 has working ones
+	ep0Stream := &hardeningMockTunnelStream{sendErr: errors.New("broken pipe")}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	// WritePacket will try ep0, Send fails, marks stream unhealthy,
+	// but does NOT trigger reconnection for ANY endpoint.
+	_ = g.WritePacket(pkt)
+
+	// Give any potential goroutines time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// CRITICAL: Neither endpoint should be reconnecting
+	if g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to be false — Send failure should NOT trigger reconnection")
+	}
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected endpointReconnecting[1] to be false — ep1 was not involved")
+	}
+
+	// ep1's streams must remain healthy
+	g.streamManager.tunnelMu.RLock()
+	for _, s := range g.streamManager.tunnelStreams {
+		if s.connIndex == 1 && !s.isHealthy {
+			t.Fatal("expected ep1 tunnel streams to remain healthy after ep0 Send failure")
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
+	// The failed stream should be marked unhealthy
+	g.streamManager.tunnelMu.RLock()
+	failedStreamUnhealthy := false
+	for _, s := range g.streamManager.tunnelStreams {
+		if s.connIndex == 0 && !s.isHealthy {
+			failedStreamUnhealthy = true
+			break
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+	if !failedStreamUnhealthy {
+		t.Fatal("expected at least one ep0 stream to be marked unhealthy after Send failure")
+	}
+}
+
+// TestWritePacket_SendFailure_StreamMarkedUnhealthy verifies that when a
+// tunnel Send() fails, the specific stream is marked unhealthy and outboundErrors
+// is incremented, while other streams remain healthy.
+func TestWritePacket_SendFailure_StreamMarkedUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	brokenStream := &hardeningMockTunnelStream{sendErr: errors.New("transport closing")}
+	healthyStream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: brokenStream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: healthyStream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	errsBefore := g.outboundErrors.Load()
+	_ = g.WritePacket(pkt)
+
+	// The failed stream should be marked unhealthy
+	g.streamManager.tunnelMu.RLock()
+	ep0Healthy := g.streamManager.tunnelStreams[0].isHealthy
+	ep1Healthy := g.streamManager.tunnelStreams[1].isHealthy
+	g.streamManager.tunnelMu.RUnlock()
+
+	if ep0Healthy {
+		t.Fatal("expected ep0 stream to be marked unhealthy after Send failure")
+	}
+	if !ep1Healthy {
+		t.Fatal("expected ep1 stream to remain healthy")
+	}
+
+	// outboundErrors should have incremented
+	if g.outboundErrors.Load() <= errsBefore {
+		t.Fatal("expected outboundErrors to increment after Send failure")
+	}
+
+	// Error metrics on the broken stream should be recorded
+	g.streamManager.metricsMu.RLock()
+	m := g.streamManager.streamMetrics["ep0-t0"]
+	g.streamManager.metricsMu.RUnlock()
+	if m == nil || m.ErrorCount == 0 {
+		t.Fatal("expected error metrics to be recorded on the failed stream")
+	}
+}
+
+// TestWritePacket_FailoverToHealthyEndpoint verifies that when the bound
+// endpoint has all unhealthy streams, WritePacket falls back to another
+// healthy endpoint and delivers the packet.
+func TestWritePacket_FailoverToHealthyEndpoint(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	ep0Stream := &hardeningMockTunnelStream{} // won't be used — streams are unhealthy
+	ep1Stream := &hardeningMockTunnelStream{} // healthy target
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	// WritePacket: selectStreamForPacket tries ep0 → no healthy tunnels
+	// → marks ep0 unhealthy → falls back to ep1
+	err := g.WritePacket(pkt)
+	if err != nil {
+		t.Fatalf("expected WritePacket to succeed via failover, got: %v", err)
+	}
+
+	// ep1's stream should have been used
+	if ep1Stream.sendCount.Load() == 0 {
+		t.Fatal("expected ep1 stream to receive the packet via failover")
+	}
+	// ep0's stream should NOT have been used (all were unhealthy)
+	if ep0Stream.sendCount.Load() != 0 {
+		t.Fatal("expected ep0 stream to NOT be used (all unhealthy)")
+	}
+
+	// ep0 should be marked unhealthy
+	if g.endpoints[0].IsHealthy() {
+		t.Fatal("expected endpoint 0 to be marked unhealthy after tunnel failure")
+	}
+	// ep1 should still be healthy
+	if !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected endpoint 1 to remain healthy")
+	}
+}
+
+// TestWritePacket_AllEndpointsDown_ReturnsError verifies that when ALL
+// endpoints have no healthy tunnel streams, WritePacket returns an error
+// without triggering reconnection (the old code would have called triggerAll).
+func TestWritePacket_AllEndpointsDown_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	// All streams unhealthy on both endpoints
+	// Mark endpoints unhealthy AND connectionHealth false (consistent)
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+
+	err := g.WritePacket(pkt)
+	if err == nil {
+		t.Fatal("expected error when all endpoints are down")
+	}
+
+	// Give potential goroutines time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// CRITICAL: No reconnection triggered from WritePacket
+	// (in old code, this would have called triggerAllEndpointReconnections)
+	// Note: selectStreamForPacket may trigger per-endpoint reconnect via
+	// triggerEndpointReconnectByURL for unhealthy endpoints, which is
+	// the correct behavior. But the WritePacket Send() path itself must
+	// NOT trigger reconnection. The reconnection here is driven by
+	// selectStreamForPacket's "no healthy tunnels" path, not by Send failure.
+}
+
+// TestWritePacket_SuccessfulSend_NoSideEffects verifies that a successful
+// WritePacket updates metrics without triggering any reconnection.
+func TestWritePacket_SuccessfulSend_NoSideEffects(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	sentBefore := g.outboundSent.Load()
+
+	err := g.WritePacket(pkt)
+	if err != nil {
+		t.Fatalf("expected WritePacket to succeed, got: %v", err)
+	}
+
+	// outboundSent should have incremented
+	if g.outboundSent.Load() <= sentBefore {
+		t.Fatal("expected outboundSent to increment after successful send")
+	}
+
+	// Stream metrics should have been updated
+	g.streamManager.metricsMu.RLock()
+	var found bool
+	for _, m := range g.streamManager.streamMetrics {
+		if m.PacketsSent > 0 {
+			found = true
+			break
+		}
+	}
+	g.streamManager.metricsMu.RUnlock()
+	if !found {
+		t.Fatal("expected stream metrics PacketsSent to be incremented")
+	}
+
+	// No reconnection flags set
+	if g.endpointReconnecting[0].Load() || g.endpointReconnecting[1].Load() {
+		t.Fatal("expected no reconnection flags set after successful send")
+	}
+
+	// Both endpoints remain healthy
+	if !g.endpoints[0].IsHealthy() || !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected both endpoints to remain healthy after successful send")
+	}
+}
+
+// --- Category B: Tunnel Liveness Per-Endpoint Tests ---
+
+// TestTunnelLiveness_StaleEndpoint_OnlyReconnectsStaleOne verifies that
+// checkTunnelStreamLiveness triggers reconnection ONLY for the endpoint with
+// stale streams, leaving healthy endpoints untouched.
+func TestTunnelLiveness_StaleEndpoint_OnlyReconnectsStaleOne(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+	g.poolConfig.StreamsPerGravity = 2
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	// Set up control streams so hasHealthyEndpoint() returns true for ep1
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	staleTimeout := 60 * time.Second
+
+	// ep0: stale streams (activity was long ago)
+	staleTime := time.Now().Add(-2 * staleTimeout).UnixMicro()
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	// ep1: recent activity
+	recentTime := time.Now().UnixMicro()
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.metricsMu.Unlock()
+
+	// Call the liveness check directly
+	g.checkTunnelStreamLiveness(staleTimeout)
+
+	// Give the goroutine time to fire
+	time.Sleep(100 * time.Millisecond)
+
+	// ep0 should be reconnecting (stale streams)
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to be true — stale streams should trigger reconnection")
+	}
+	// ep1 should NOT be reconnecting (recent activity)
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected endpointReconnecting[1] to be false — streams have recent activity")
+	}
+
+	// ep1 should remain healthy
+	if !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected endpoint 1 to remain healthy after ep0 liveness failure")
+	}
+}
+
+// TestTunnelLiveness_IdleStreams_NoReconnection verifies that streams with
+// zero timestamps (never carried data) are NOT flagged as stale. This prevents
+// reconnection loops on idle hadrons with no containers.
+func TestTunnelLiveness_IdleStreams_NoReconnection(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+	g.poolConfig.StreamsPerGravity = 2
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	// All streams have zero timestamps (idle — never carried data)
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.metricsMu.Unlock()
+
+	g.checkTunnelStreamLiveness(60 * time.Second)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Neither endpoint should be reconnecting
+	if g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to be false — idle streams should not trigger reconnection")
+	}
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected endpointReconnecting[1] to be false — idle streams should not trigger reconnection")
+	}
+}
+
+// --- Category C: selectStreamForPacket Per-Endpoint Reconnection ---
+
+// TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconnect
+// verifies that when all tunnel streams for an endpoint are unhealthy,
+// selectStreamForPacket marks the endpoint unhealthy, triggers per-endpoint
+// reconnection via triggerEndpointReconnectByURL, and falls back to ep1.
+func TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconnect(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	stream, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected selectStreamForPacket to succeed via fallback, got: %v", err)
+	}
+
+	// Should have fallen back to ep1
+	if stream.connIndex != 1 {
+		t.Fatalf("expected stream from endpoint 1, got connIndex=%d", stream.connIndex)
+	}
+
+	// ep0 should now be marked unhealthy
+	if g.endpoints[0].IsHealthy() {
+		t.Fatal("expected endpoint 0 to be marked unhealthy after tunnel failure")
+	}
+
+	// Give triggerEndpointReconnectByURL goroutine time to fire
+	time.Sleep(100 * time.Millisecond)
+
+	// ep0 should be reconnecting (triggered by selectStreamForPacket)
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to be true — triggerEndpointReconnectByURL should have been called")
+	}
+
+	// ep1 should NOT be reconnecting
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected endpointReconnecting[1] to be false — ep1 is healthy")
+	}
+}
+
+// --- Category D: Safety Net Edge Cases ---
+
+// TestTriggerAllEndpointReconnections_ClosingClient verifies that
+// triggerAllEndpointReconnections returns immediately when closing=true.
+func TestTriggerAllEndpointReconnections_ClosingClient(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 3)
+	g.gravityURLs = []string{"a", "b", "c"}
+
+	// All endpoints unhealthy
+	for i := 0; i < 3; i++ {
+		g.endpoints[i].healthy.Store(false)
+		g.streamManager.connectionHealth[i] = false
+	}
+
+	g.mu.Lock()
+	g.closing = true
+	g.mu.Unlock()
+
+	g.triggerAllEndpointReconnections("closing_test")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// No endpoints should be reconnecting
+	for i := 0; i < 3; i++ {
+		if g.endpointReconnecting[i].Load() {
+			t.Fatalf("expected endpointReconnecting[%d] to be false when closing", i)
+		}
+	}
+}
+
+// TestTriggerAllEndpointReconnections_AlreadyReconnecting verifies that
+// when an endpoint is already reconnecting, the CAS fails and it's not
+// disrupted. Healthy endpoints are also skipped.
+func TestTriggerAllEndpointReconnections_AlreadyReconnecting(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "t0"},
+		{connIndex: 1, isHealthy: true, streamID: "t1"},
+	}
+
+	// ep0 already reconnecting AND unhealthy
+	g.endpointReconnecting[0].Store(true)
+	g.endpoints[0].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+
+	// ep1 healthy
+	// endpoints[1].healthy is already true from newEndpointTestClient
+
+	g.triggerAllEndpointReconnections("already_reconnecting_test")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// ep0 should still be reconnecting (CAS failed, not re-entered)
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to remain true (CAS should fail)")
+	}
+
+	// ep1 should NOT be reconnecting (healthy, skipped by safety net)
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected endpointReconnecting[1] to be false — healthy endpoint should be skipped")
+	}
+
+	// ep1's control stream should remain intact
+	g.streamManager.controlMu.RLock()
+	if g.streamManager.controlStreams[1] == nil {
+		t.Fatal("expected healthy endpoint 1 control stream to remain intact")
+	}
+	g.streamManager.controlMu.RUnlock()
+}
+
+// TestTriggerAllEndpointReconnections_ConcurrentCalls verifies that
+// concurrent calls to triggerAllEndpointReconnections only reconnect
+// each endpoint at most once (CAS protects).
+func TestTriggerAllEndpointReconnections_ConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	g := &GravityClient{
+		logger:                logger.NewTestLogger(),
+		ctx:                   ctx,
+		cancel:                cancel,
+		retryConfig:           DefaultRetryConfig(),
+		connections:           make([]*grpc.ClientConn, 3),
+		sessionClients:        make([]pb.GravitySessionServiceClient, 3),
+		connectionURLs:        []string{"grpc://ep-0", "grpc://ep-1", "grpc://ep-2"},
+		endpoints:             make([]*GravityEndpoint, 3),
+		endpointReconnecting:  make([]atomic.Bool, 3),
+		circuitBreakers:       make([]*CircuitBreaker, 3),
+		connectionIDChan:      make(chan string, 16),
+		endpointStreamIndices: make(map[string][]int),
+		closed:                make(chan struct{}, 1),
+		peerDiscoveryWake:     make(chan struct{}, 1),
+		streamManager: &StreamManager{
+			controlStreams:   make([]pb.GravitySessionService_EstablishSessionClient, 3),
+			controlSendMu:    make([]sync.Mutex, 3),
+			tunnelStreams:    make([]*StreamInfo, 0),
+			connectionHealth: make([]bool, 3),
+			streamMetrics:    make(map[string]*StreamMetrics),
+			contexts:         make([]context.Context, 3),
+			cancels:          make([]context.CancelFunc, 3),
+		},
+	}
+	for i := 0; i < 3; i++ {
+		ep := &GravityEndpoint{URL: g.connectionURLs[i]}
+		ep.healthy.Store(false) // All unhealthy
+		g.endpoints[i] = ep
+		g.streamManager.connectionHealth[i] = false
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+		g.circuitBreakers[i] = NewCircuitBreaker(DefaultCircuitBreakerConfig())
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "t0"},
+		{connIndex: 1, isHealthy: true, streamID: "t1"},
+		{connIndex: 2, isHealthy: true, streamID: "t2"},
+	}
+	g.multiEndpointMode.Store(true)
+
+	// Cancel context to prevent infinite reconnect loops
+	cancel()
+
+	// 10 goroutines call triggerAll simultaneously
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			g.triggerAllEndpointReconnections(fmt.Sprintf("concurrent_%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// All control streams should be nil (disconnected)
+	g.streamManager.controlMu.RLock()
+	for i, cs := range g.streamManager.controlStreams {
+		if cs != nil {
+			t.Fatalf("expected control stream %d to be nil after concurrent triggerAll", i)
+		}
+	}
+	g.streamManager.controlMu.RUnlock()
+}
+
+// TestTriggerAllEndpointReconnections_SingleEndpointMode verifies backward
+// compatibility: with 1 endpoint (unhealthy), triggerAll reconnects it.
+func TestTriggerAllEndpointReconnections_SingleEndpointMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	g := &GravityClient{
+		logger:                logger.NewTestLogger(),
+		ctx:                   ctx,
+		cancel:                cancel,
+		retryConfig:           DefaultRetryConfig(),
+		connections:           make([]*grpc.ClientConn, 1),
+		sessionClients:        make([]pb.GravitySessionServiceClient, 1),
+		connectionURLs:        []string{"grpc://ep-0"},
+		endpoints:             make([]*GravityEndpoint, 1),
+		endpointReconnecting:  make([]atomic.Bool, 1),
+		circuitBreakers:       make([]*CircuitBreaker, 1),
+		connectionIDChan:      make(chan string, 16),
+		endpointStreamIndices: make(map[string][]int),
+		closed:                make(chan struct{}, 1),
+		peerDiscoveryWake:     make(chan struct{}, 1),
+		streamManager: &StreamManager{
+			controlStreams:   make([]pb.GravitySessionService_EstablishSessionClient, 1),
+			controlSendMu:    make([]sync.Mutex, 1),
+			tunnelStreams:    make([]*StreamInfo, 0),
+			connectionHealth: []bool{false},
+			streamMetrics:    make(map[string]*StreamMetrics),
+			contexts:         make([]context.Context, 1),
+			cancels:          make([]context.CancelFunc, 1),
+		},
+	}
+	ep := &GravityEndpoint{URL: "grpc://ep-0"}
+	ep.healthy.Store(false)
+	g.endpoints[0] = ep
+	g.circuitBreakers[0] = NewCircuitBreaker(DefaultCircuitBreakerConfig())
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+
+	// Cancel so reconnect goroutine exits
+	cancel()
+
+	g.triggerAllEndpointReconnections("single_endpoint_test")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// The single unhealthy endpoint should have been disconnected
+	g.streamManager.controlMu.RLock()
+	cs := g.streamManager.controlStreams[0]
+	g.streamManager.controlMu.RUnlock()
+	if cs != nil {
+		t.Fatal("expected control stream 0 to be nil (disconnected)")
+	}
+}
+
+// --- Category E: handleEndpointDisconnection ---
+
+// TestHandleEndpointDisconnection_TargetsOnlySpecificEndpoint verifies that
+// with 3 endpoints, disconnecting endpoint 1 only affects endpoint 1.
+// This is similar to TestHandleEndpointDisconnection_IsolatesOthers but
+// explicitly checks that triggerAll is NOT called.
+func TestHandleEndpointDisconnection_TargetsOnlySpecificEndpoint(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 3)
+	g.gravityURLs = []string{"a", "b", "c"}
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+		{connIndex: 2, isHealthy: true, streamID: "s2"},
+	}
+
+	g.handleEndpointDisconnection(1, "test_targets_specific")
+
+	// Give the goroutine a moment to fire, then cancel to stop reconnect loop
+	time.Sleep(50 * time.Millisecond)
+	g.cancel()
+
+	// Wait for the reconnect goroutine to exit
+	deadline := time.Now().Add(2 * time.Second)
+	for g.endpointReconnecting[1].Load() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Only endpoint 1 should have been disconnected
+	if g.streamManager.controlStreams[1] != nil {
+		t.Fatal("expected control stream 1 to be nil")
+	}
+	if g.streamManager.controlStreams[0] == nil {
+		t.Fatal("expected control stream 0 to remain intact")
+	}
+	if g.streamManager.controlStreams[2] == nil {
+		t.Fatal("expected control stream 2 to remain intact")
+	}
+
+	// Endpoint 0 and 2 should NOT be reconnecting
+	if g.endpointReconnecting[0].Load() {
+		t.Fatal("expected endpointReconnecting[0] to be false")
+	}
+	if g.endpointReconnecting[2].Load() {
+		t.Fatal("expected endpointReconnecting[2] to be false")
+	}
+}
+
+// TestHandleEndpointDisconnection_DegradedModeLogging verifies that when
+// one endpoint is disconnected but others are healthy, the system operates
+// in degraded mode (hasHealthyEndpoint returns true).
+func TestHandleEndpointDisconnection_DegradedModeLogging(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 3)
+	g.gravityURLs = []string{"a", "b", "c"}
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+		{connIndex: 2, isHealthy: true, streamID: "s2"},
+	}
+
+	g.handleEndpointDisconnection(1, "degraded_test")
+
+	time.Sleep(50 * time.Millisecond)
+	g.cancel()
+
+	// Wait for reconnect goroutine to finish
+	deadline := time.Now().Add(2 * time.Second)
+	for g.endpointReconnecting[1].Load() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// hasHealthyEndpoint should return true because ep0 and ep2 are still healthy
+	// (they have control streams and healthy tunnel streams)
+	if !g.hasHealthyEndpoint() {
+		t.Fatal("expected hasHealthyEndpoint() to return true — ep0 and ep2 are still healthy")
+	}
+
+	// Control streams for 0 and 2 must remain intact
+	g.streamManager.controlMu.RLock()
+	if g.streamManager.controlStreams[0] == nil {
+		t.Fatal("expected ep0 control stream to remain intact")
+	}
+	if g.streamManager.controlStreams[2] == nil {
+		t.Fatal("expected ep2 control stream to remain intact")
+	}
+	g.streamManager.controlMu.RUnlock()
+
+	// Endpoint 1 should be marked unhealthy
+	if g.endpoints[1].IsHealthy() {
+		t.Fatal("expected endpoint 1 to be marked unhealthy")
+	}
+
+	// Endpoints 0 and 2 should remain healthy
+	if !g.endpoints[0].IsHealthy() || !g.endpoints[2].IsHealthy() {
+		t.Fatal("expected endpoints 0 and 2 to remain healthy")
+	}
+}
+
+// --- Category F: Recovery ---
+
+// TestWritePacket_AfterEndpointRecovery_TrafficResumes verifies that after
+// an endpoint's streams are restored to healthy, traffic resumes through it.
+func TestWritePacket_AfterEndpointRecovery_TrafficResumes(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: false, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	// Mark ep0 as unhealthy consistently
+	g.endpoints[0].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	// Phase 1: ep0 down → routes to ep1
+	err := g.WritePacket(pkt)
+	if err != nil {
+		t.Fatalf("expected WritePacket to succeed via ep1 failover, got: %v", err)
+	}
+	if ep1Stream.sendCount.Load() == 0 {
+		t.Fatal("expected traffic to route to ep1 when ep0 is down")
+	}
+
+	ep1CountAfterPhase1 := ep1Stream.sendCount.Load()
+
+	// Phase 2: "Recover" ep0 — mark streams healthy again
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams[0].isHealthy = true
+	g.streamManager.tunnelStreams[1].isHealthy = true
+	g.streamManager.tunnelMu.Unlock()
+
+	g.endpoints[0].healthy.Store(true)
+	g.streamManager.healthMu.Lock()
+	g.streamManager.connectionHealth[0] = true
+	g.streamManager.healthMu.Unlock()
+
+	// Re-bind flow to ep0
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	// Phase 3: ep0 recovered → traffic should resume on ep0
+	err = g.WritePacket(pkt)
+	if err != nil {
+		t.Fatalf("expected WritePacket to succeed via recovered ep0, got: %v", err)
+	}
+
+	// ep0 should have received a packet now
+	if ep0Stream.sendCount.Load() == 0 {
+		t.Fatal("expected traffic to resume through recovered ep0")
+	}
+
+	// ep1 should not have received additional packets
+	if ep1Stream.sendCount.Load() != ep1CountAfterPhase1 {
+		t.Fatalf("expected ep1 send count unchanged after ep0 recovery, got %d (was %d)", ep1Stream.sendCount.Load(), ep1CountAfterPhase1)
+	}
+}
+
+// --- Additional edge case tests ---
+
+// TestWritePacket_ConcurrentMultiEndpoint verifies that concurrent WritePacket
+// calls across multiple endpoints don't cause data races or panics.
+func TestWritePacket_ConcurrentMultiEndpoint(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	const workers = 50
+	const packetsPerWorker = 100
+
+	var wg sync.WaitGroup
+	panicCh := make(chan any, 1)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					select {
+					case panicCh <- p:
+					default:
+					}
+				}
+			}()
+
+			for j := 0; j < packetsPerWorker; j++ {
+				pkt := make([]byte, 54)
+				pkt[0] = 0x60
+				pkt[6] = 6 // TCP
+				// Vary dst IP to create different flows
+				pkt[39] = byte(workerID)
+				pkt[43] = byte(j)
+				_ = g.WritePacket(pkt)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	select {
+	case p := <-panicCh:
+		t.Fatalf("panic during concurrent WritePacket: %v", p)
+	default:
+	}
+
+	// Both endpoints should have received some traffic
+	totalSent := ep0Stream.sendCount.Load() + ep1Stream.sendCount.Load()
+	if totalSent == 0 {
+		t.Fatal("expected some packets to be sent across endpoints")
+	}
+}
+
+// TestSelectStreamForPacket_SingleEndpointFallback verifies that with a
+// single endpoint (selector != nil but only 1 endpoint), the backward-
+// compatible global stream selection path is used.
+func TestSelectStreamForPacket_SingleEndpointFallback(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 1)
+	g.multiEndpointMode.Store(false) // single endpoint mode
+
+	stream := &hardeningMockTunnelStream{}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0", stream: stream, lastUsed: time.Now()},
+	}
+	g.streamManager.streamMetrics["s0"] = &StreamMetrics{}
+
+	pkt := makeIPv6Packet()
+	si, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected stream selection to succeed, got: %v", err)
+	}
+	if si.streamID != "s0" {
+		t.Fatalf("expected stream s0, got %s", si.streamID)
+	}
+}
+
+// TestTunnelLiveness_AllEndpointsStale_OnlyReconnectsFirst verifies that
+// checkTunnelStreamLiveness reconnects one endpoint at a time, not all.
+func TestTunnelLiveness_AllEndpointsStale_OnlyReconnectsFirst(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+	g.poolConfig.StreamsPerGravity = 2
+
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	})
+
+	// Set up control streams
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	staleTimeout := 60 * time.Second
+	staleTime := time.Now().Add(-2 * staleTimeout).UnixMicro()
+
+	// Both endpoints stale
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.metricsMu.Unlock()
+
+	g.checkTunnelStreamLiveness(staleTimeout)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// The function returns after the first reconnection — only one endpoint
+	// should be reconnecting per cycle.
+	reconnectingCount := 0
+	if g.endpointReconnecting[0].Load() {
+		reconnectingCount++
+	}
+	if g.endpointReconnecting[1].Load() {
+		reconnectingCount++
+	}
+
+	if reconnectingCount != 1 {
+		t.Fatalf("expected exactly 1 endpoint reconnecting per liveness cycle, got %d", reconnectingCount)
+	}
+}
+
+// TestDisconnectEndpointStreams_RefreshesHealth verifies that
+// disconnectEndpointStreams calls refreshEndpointHealth, which re-derives
+// endpoint health from connectionHealth. This is the critical discovery:
+// if tests set endpoint.healthy=false but leave connectionHealth=true,
+// refreshEndpointHealth will override the test's intent.
+func TestDisconnectEndpointStreams_RefreshesHealth(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+	}
+
+	// Before disconnecting ep0, both are healthy
+	if !g.endpoints[0].IsHealthy() || !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected both endpoints healthy before disconnect")
+	}
+
+	g.disconnectEndpointStreams(0)
+
+	// After disconnecting ep0:
+	// - connectionHealth[0] should be false
+	// - endpoint 0 should be unhealthy (refreshEndpointHealth derives from connectionHealth)
+	// - endpoint 1 should remain healthy (connectionHealth[1] still true)
+	if g.streamManager.connectionHealth[0] {
+		t.Fatal("expected connectionHealth[0]=false after disconnect")
+	}
+	if g.endpoints[0].IsHealthy() {
+		t.Fatal("expected endpoint 0 unhealthy after disconnectEndpointStreams")
+	}
+	if !g.endpoints[1].IsHealthy() {
+		t.Fatal("expected endpoint 1 to remain healthy after ep0 disconnect")
+	}
+}
+
+// TestWritePacket_SingleEndpointBrokenStream verifies WritePacket behavior
+// when a single-endpoint client has a broken stream: it marks the stream
+// unhealthy, does NOT trigger reconnection from the Write path.
+func TestWritePacket_SingleEndpointBrokenStream(t *testing.T) {
+	t.Parallel()
+
+	g := newHardeningGravityClient(t, 1)
+	g.streamManager.allocationStrategy = RoundRobin
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+
+	brokenStream := &hardeningMockTunnelStream{sendErr: errors.New("stream reset")}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0", stream: brokenStream, lastUsed: time.Now()},
+	}
+	g.streamManager.connectionHealth[0] = true
+	g.streamManager.streamMetrics["s0"] = &StreamMetrics{}
+
+	pkt := make([]byte, 44)
+	pkt[0] = 0x60
+
+	err := g.WritePacket(pkt)
+	// The error should propagate (stream.Send failed)
+	if err == nil {
+		t.Fatal("expected WritePacket to return error for broken stream")
+	}
+
+	// Stream should be marked unhealthy
+	g.streamManager.tunnelMu.RLock()
+	if g.streamManager.tunnelStreams[0].isHealthy {
+		t.Fatal("expected stream to be marked unhealthy after Send failure")
+	}
+	g.streamManager.tunnelMu.RUnlock()
+}
+
+// TestWritePacket_ClosingClient verifies WritePacket returns
+// ErrConnectionClosed when the client is shutting down.
+func TestWritePacket_ClosingClient(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.mu.Lock()
+	g.closing = true
+	g.mu.Unlock()
+
+	pkt := makeIPv6Packet()
+	err := g.WritePacket(pkt)
+	if !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected ErrConnectionClosed, got %v", err)
+	}
+}
+
+// TestWritePacket_NotConnected verifies WritePacket returns
+// ErrConnectionClosed when the client is not connected.
+func TestWritePacket_NotConnected(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.mu.Lock()
+	g.connected = false
+	g.mu.Unlock()
+
+	pkt := makeIPv6Packet()
+	err := g.WritePacket(pkt)
+	if !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected ErrConnectionClosed, got %v", err)
+	}
+}
+
+// --- AGNT Keepalive Liveness Gap Tests ---
+//
+// These tests verify the exact behavior of the AGNT keepalive mechanism
+// and expose a gap: sendTunnelKeepalives does NOT update LastSendUs in
+// stream metrics, so if an ion dies before the first AGNT echo ever
+// arrives, the liveness monitor sees zero timestamps and classifies the
+// stream as "idle" rather than "stale" — the dead endpoint is invisible.
+
+// TestAGNTKeepalive_SendsProbesOnIdleHadron verifies that
+// sendTunnelKeepalives sends probes on healthy streams regardless of
+// whether any container traffic has flowed. This is the AGNT liveness
+// mechanism that keeps idle connections alive.
+func TestAGNTKeepalive_SendsProbesOnIdleHadron(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+	g.poolConfig.StreamsPerGravity = 2
+
+	// Set up tunnel streams with mock streams that track Send calls.
+	// No container traffic — this is a completely idle hadron.
+	ep0Stream := &hardeningMockTunnelStream{}
+	ep1Stream := &hardeningMockTunnelStream{}
+
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1", stream: ep0Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0", stream: ep1Stream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1", stream: ep1Stream, lastUsed: time.Now()},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{}
+	g.streamManager.metricsMu.Unlock()
+
+	g.sendTunnelKeepalives()
+
+	// Goroutines run async — wait for them to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	// Probes SHOULD be sent on both endpoints (one stream per endpoint per rotation).
+	ep0Sends := ep0Stream.sendCount.Load()
+	ep1Sends := ep1Stream.sendCount.Load()
+
+	if ep0Sends == 0 {
+		t.Fatal("expected AGNT probe sent to endpoint 0 — keepalive not running on idle hadron")
+	}
+	if ep1Sends == 0 {
+		t.Fatal("expected AGNT probe sent to endpoint 1 — keepalive not running on idle hadron")
+	}
+}
+
+// TestAGNTKeepalive_DoesNotUpdateLastSendUs verifies that
+// sendTunnelKeepalives does NOT update LastSendUs in stream metrics.
+// This is the root of the idle-hadron detection gap: without a
+// LastSendUs update, the liveness monitor sees zero timestamps and
+// classifies the stream as "idle" instead of "probe sent, no echo."
+//
+// If this test PASSES, the gap exists and should be fixed.
+// If this test FAILS, the gap has been fixed.
+func TestAGNTKeepalive_DoesNotUpdateLastSendUs(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 1)
+	g.poolConfig.StreamsPerGravity = 1
+
+	mockStream := &hardeningMockTunnelStream{}
+
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0", stream: mockStream, lastUsed: time.Now()},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["s0"] = &StreamMetrics{} // LastSendUs = 0
+	g.streamManager.metricsMu.Unlock()
+
+	g.sendTunnelKeepalives()
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify probe was sent.
+	if mockStream.sendCount.Load() == 0 {
+		t.Fatal("expected AGNT probe to be sent")
+	}
+
+	// Check if LastSendUs was updated.
+	g.streamManager.metricsMu.Lock()
+	lastSendUs := g.streamManager.streamMetrics["s0"].LastSendUs
+	g.streamManager.metricsMu.Unlock()
+
+	// After fix: sendTunnelKeepalives updates LastSendUs on first
+	// successful probe, promoting the stream from "idle" to "probed."
+	if lastSendUs == 0 {
+		t.Fatal("sendTunnelKeepalives must update LastSendUs on first probe — dead endpoints on idle hadrons would be invisible to liveness monitor")
+	}
+}
+
+// TestAGNTKeepalive_SendFailure_DoesNotMarkStreamUnhealthy verifies that
+// when an AGNT probe Send() fails, the stream is NOT marked unhealthy.
+// The error is silently discarded.
+//
+// If this test PASSES, the gap exists.
+// If this test FAILS, the gap has been fixed.
+func TestAGNTKeepalive_SendFailure_DoesNotMarkStreamUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 1)
+	g.poolConfig.StreamsPerGravity = 1
+
+	mockStream := &hardeningMockTunnelStream{sendErr: fmt.Errorf("connection broken")}
+
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0", stream: mockStream, lastUsed: time.Now()},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["s0"] = &StreamMetrics{}
+	g.streamManager.metricsMu.Unlock()
+
+	g.sendTunnelKeepalives()
+	time.Sleep(100 * time.Millisecond)
+
+	// Check if the stream was marked unhealthy after Send failure.
+	g.streamManager.tunnelMu.RLock()
+	stillHealthy := g.streamManager.tunnelStreams[0].isHealthy
+	g.streamManager.tunnelMu.RUnlock()
+
+	// Send failure on probe does NOT mark stream unhealthy — this is
+	// intentional. A single transient Send failure shouldn't flap the
+	// stream. The liveness monitor detects dead endpoints via stale
+	// timestamps (no echo received within staleTimeout).
+	if !stillHealthy {
+		t.Fatal("AGNT probe Send failure should NOT mark stream unhealthy — that's too aggressive for a transient error")
+	}
+}
+
+// TestLiveness_TrulyIdleStreams_NotFlaggedAsStale verifies that streams
+// where BOTH LastSendUs and LastRecvUs are zero (never probed, never
+// received) are correctly classified as "idle" — not stale. This prevents
+// false-positive reconnection on streams that were just established.
+func TestLiveness_TrulyIdleStreams_NotFlaggedAsStale(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+	g.poolConfig.StreamsPerGravity = 2
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0"},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1"},
+	}
+
+	// BOTH timestamps zero — stream just established, no probe yet.
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: 0, LastRecvUs: 0}
+	g.streamManager.metricsMu.Unlock()
+
+	staleTimeout := 30 * time.Second
+	g.checkTunnelStreamLiveness(staleTimeout)
+	time.Sleep(100 * time.Millisecond)
+
+	// Truly idle streams (both zero) should NOT trigger reconnection.
+	if g.endpointReconnecting[0].Load() || g.endpointReconnecting[1].Load() {
+		t.Fatal("truly idle streams (zero timestamps) should NOT be flagged as stale")
+	}
+}
+
+// TestLiveness_ProbedButNoEcho_DetectsDeadEndpoint verifies that the
+// liveness monitor detects dead endpoints when a probe was sent
+// (LastSendUs > 0) but no echo ever came back (LastRecvUs == 0).
+// This is the "ion dies before first AGNT echo" scenario on idle hadrons.
+func TestLiveness_ProbedButNoEcho_DetectsDeadEndpoint(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+	g.poolConfig.StreamsPerGravity = 2
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0"},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1"},
+	}
+
+	staleTimeout := 30 * time.Second
+	// ep0: probed 60s ago, never got echo — dead endpoint
+	oldProbeTime := time.Now().Add(-2 * staleTimeout).UnixMicro()
+	// ep1: probed recently, echo received — healthy
+	recentTime := time.Now().UnixMicro()
+
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: oldProbeTime, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: oldProbeTime, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.metricsMu.Unlock()
+
+	g.checkTunnelStreamLiveness(staleTimeout)
+	time.Sleep(100 * time.Millisecond)
+
+	// ep0: probed but no echo, probe time is stale → MUST be detected
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected dead endpoint 0 (probed, no echo, stale) to enter reconnection")
+	}
+	// ep1: healthy (recent echo)
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected healthy endpoint 1 to NOT enter reconnection")
+	}
+}
+
+// TestLiveness_NonZeroStaleTimestamps_DetectsDeadEndpoint verifies the
+// NORMAL case: when AGNT echoes were flowing (non-zero timestamps) and
+// then stopped (timestamps go stale), the liveness monitor correctly
+// detects the dead endpoint and triggers reconnection.
+func TestLiveness_NonZeroStaleTimestamps_DetectsDeadEndpoint(t *testing.T) {
+	t.Parallel()
+
+	g := newEndpointTestClient(t, 2)
+	g.gravityURLs = []string{"a", "b"}
+	g.poolConfig.StreamsPerGravity = 2
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+
+	for i := range g.streamManager.controlStreams {
+		g.streamManager.controlStreams[i] = &configurableMockStream{}
+	}
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0"},
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t1"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t0"},
+		{connIndex: 1, isHealthy: true, streamID: "ep1-t1"},
+	}
+
+	staleTimeout := 60 * time.Second
+	staleTime := time.Now().Add(-2 * staleTimeout).UnixMicro() // well past stale
+	recentTime := time.Now().UnixMicro()                       // fresh
+
+	// ep0: stale (ion died, no AGNT echoes for >60s)
+	// ep1: fresh (AGNT echoes still arriving)
+	g.streamManager.metricsMu.Lock()
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: staleTime, LastRecvUs: staleTime}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.metricsMu.Unlock()
+
+	g.checkTunnelStreamLiveness(staleTimeout)
+	time.Sleep(100 * time.Millisecond)
+
+	// ep0 should be reconnecting (stale streams detected).
+	if !g.endpointReconnecting[0].Load() {
+		t.Fatal("expected stale endpoint 0 to enter reconnection — liveness monitor failed")
+	}
+	// ep1 should NOT be reconnecting (fresh streams).
+	if g.endpointReconnecting[1].Load() {
+		t.Fatal("expected fresh endpoint 1 to NOT enter reconnection")
+	}
 }

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1407,13 +1407,47 @@ func TestWritePacket_AllEndpointsDown_ReturnsError(t *testing.T) {
 	// Give potential goroutines time to start
 	time.Sleep(50 * time.Millisecond)
 
-	// CRITICAL: No reconnection triggered from WritePacket
-	// (in old code, this would have called triggerAllEndpointReconnections)
+	// CRITICAL: Verify triggerAllEndpointReconnections was NOT called.
+	// triggerAllEndpointReconnections would have called disconnectEndpointStreams,
+	// which nils control streams and marks tunnel streams unhealthy, and closes
+	// gRPC connections. If any of these are intact, triggerAll was not invoked.
+	//
 	// Note: selectStreamForPacket may trigger per-endpoint reconnect via
 	// triggerEndpointReconnectByURL for unhealthy endpoints, which is
 	// the correct behavior. But the WritePacket Send() path itself must
 	// NOT trigger reconnection. The reconnection here is driven by
 	// selectStreamForPacket's "no healthy tunnels" path, not by Send failure.
+
+	// Verify ep0's tunnel streams were not nil'd by triggerAllEndpointReconnections.
+	// disconnectEndpointStreams would have set isHealthy=false on all tunnel streams
+	// for the endpoint AND nil'd the control stream / closed the gRPC connection.
+	g.streamManager.tunnelMu.RLock()
+	for _, si := range g.streamManager.tunnelStreams {
+		if si != nil && si.stream == nil {
+			g.streamManager.tunnelMu.RUnlock()
+			t.Fatal("triggerAllEndpointReconnections was called: tunnel stream was disconnected")
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
+	// Verify that ep1's control stream is still intact (not nil'd by disconnectEndpointStreams).
+	// If triggerAll was called, it would have nil'd the control stream for unhealthy endpoints.
+	g.streamManager.controlMu.RLock()
+	// controlStreams are nil in this test fixture (newWritePacketTestClient doesn't set them),
+	// so instead verify that no gRPC connections were closed by checking the mock streams.
+	g.streamManager.controlMu.RUnlock()
+
+	// The most reliable signal: ep0Stream and ep1Stream should not have been
+	// used by Send (triggerAllEndpointReconnections doesn't Send, but
+	// disconnectEndpointStreams would mark streams unhealthy and trigger
+	// reconnectEndpoint which could interact with streams). Since both
+	// endpoints were already unhealthy, their send counts should be zero.
+	if ep0Stream.sendCount.Load() != 0 {
+		t.Fatal("triggerAllEndpointReconnections side effect: ep0 stream was used")
+	}
+	if ep1Stream.sendCount.Load() != 0 {
+		t.Fatal("triggerAllEndpointReconnections side effect: ep1 stream was used")
+	}
 }
 
 // TestWritePacket_SuccessfulSend_NoSideEffects verifies that a successful
@@ -2318,13 +2352,15 @@ func TestAGNTKeepalive_SendsProbesOnIdleHadron(t *testing.T) {
 	}
 }
 
-// TestAGNTKeepalive_UpdatesLastSendUsOnFirstProbe verifies that
-// sendTunnelKeepalives updates LastSendUs on the first successful probe,
+// TestAGNTKeepalive_UpdatesLastProbeSentUs verifies that
+// sendTunnelKeepalives updates LastProbeSentUs on every successful probe,
 // promoting the stream from "idle" (zero timestamps) to "probed." This
 // enables the liveness monitor to detect dead endpoints on idle hadrons
 // where no user traffic flows — without this update, the monitor would
 // see zero timestamps and classify the stream as idle instead of stale.
-func TestAGNTKeepalive_UpdatesLastSendUsOnFirstProbe(t *testing.T) {
+// LastProbeSentUs is separate from LastSendUs (updated by data traffic)
+// to prevent WritePacket sends from masking zombie tunnels.
+func TestAGNTKeepalive_UpdatesLastProbeSentUs(t *testing.T) {
 	t.Parallel()
 
 	g := newWritePacketTestClient(t, 1)
@@ -2350,15 +2386,17 @@ func TestAGNTKeepalive_UpdatesLastSendUsOnFirstProbe(t *testing.T) {
 		t.Fatal("expected AGNT probe to be sent")
 	}
 
-	// Check if LastSendUs was updated.
+	// Check if LastProbeSentUs was updated.
 	g.streamManager.metricsMu.Lock()
-	lastSendUs := g.streamManager.streamMetrics["s0"].LastSendUs
+	lastProbeSentUs := g.streamManager.streamMetrics["s0"].LastProbeSentUs
 	g.streamManager.metricsMu.Unlock()
 
-	// After fix: sendTunnelKeepalives updates LastSendUs on first
+	// After fix: sendTunnelKeepalives updates LastProbeSentUs on every
 	// successful probe, promoting the stream from "idle" to "probed."
-	if lastSendUs == 0 {
-		t.Fatal("sendTunnelKeepalives must update LastSendUs on first probe — dead endpoints on idle hadrons would be invisible to liveness monitor")
+	// LastProbeSentUs is separate from LastSendUs (data traffic) to
+	// prevent WritePacket sends from masking zombie tunnels.
+	if lastProbeSentUs == 0 {
+		t.Fatal("sendTunnelKeepalives must update LastProbeSentUs on probe — dead endpoints on idle hadrons would be invisible to liveness monitor")
 	}
 }
 
@@ -2444,7 +2482,7 @@ func TestLiveness_TrulyIdleStreams_NotFlaggedAsStale(t *testing.T) {
 
 // TestLiveness_ProbedButNoEcho_DetectsDeadEndpoint verifies that the
 // liveness monitor detects dead endpoints when a probe was sent
-// (LastSendUs > 0) but no echo ever came back (LastRecvUs == 0).
+// (LastProbeSentUs > 0) but no echo ever came back (LastRecvUs == 0).
 // This is the "ion dies before first AGNT echo" scenario on idle hadrons.
 func TestLiveness_ProbedButNoEcho_DetectsDeadEndpoint(t *testing.T) {
 	t.Parallel()
@@ -2471,10 +2509,10 @@ func TestLiveness_ProbedButNoEcho_DetectsDeadEndpoint(t *testing.T) {
 	recentTime := time.Now().UnixMicro()
 
 	g.streamManager.metricsMu.Lock()
-	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastSendUs: oldProbeTime, LastRecvUs: 0}
-	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastSendUs: oldProbeTime, LastRecvUs: 0}
-	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
-	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastSendUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.streamMetrics["ep0-t0"] = &StreamMetrics{LastProbeSentUs: oldProbeTime, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep0-t1"] = &StreamMetrics{LastProbeSentUs: oldProbeTime, LastRecvUs: 0}
+	g.streamManager.streamMetrics["ep1-t0"] = &StreamMetrics{LastProbeSentUs: recentTime, LastRecvUs: recentTime}
+	g.streamManager.streamMetrics["ep1-t1"] = &StreamMetrics{LastProbeSentUs: recentTime, LastRecvUs: recentTime}
 	g.streamManager.metricsMu.Unlock()
 
 	g.checkTunnelStreamLiveness(staleTimeout)

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1160,7 +1160,7 @@ func newWritePacketTestClient(t *testing.T, n int) *GravityClient {
 	return g
 }
 
-// makeIPv6Packet creates a minimal 44-byte IPv6 packet with TCP next header.
+// makeIPv6Packet creates a minimal 54-byte IPv6 packet with TCP next header.
 // Bytes 0: version nibble (0x60), byte 6: next header (TCP=6), bytes 8-23: src IP,
 // bytes 24-39: dst IP, bytes 40-43: src/dst ports.
 func makeIPv6Packet() []byte {
@@ -2318,15 +2318,13 @@ func TestAGNTKeepalive_SendsProbesOnIdleHadron(t *testing.T) {
 	}
 }
 
-// TestAGNTKeepalive_DoesNotUpdateLastSendUs verifies that
-// sendTunnelKeepalives does NOT update LastSendUs in stream metrics.
-// This is the root of the idle-hadron detection gap: without a
-// LastSendUs update, the liveness monitor sees zero timestamps and
-// classifies the stream as "idle" instead of "probe sent, no echo."
-//
-// If this test PASSES, the gap exists and should be fixed.
-// If this test FAILS, the gap has been fixed.
-func TestAGNTKeepalive_DoesNotUpdateLastSendUs(t *testing.T) {
+// TestAGNTKeepalive_UpdatesLastSendUsOnFirstProbe verifies that
+// sendTunnelKeepalives updates LastSendUs on the first successful probe,
+// promoting the stream from "idle" (zero timestamps) to "probed." This
+// enables the liveness monitor to detect dead endpoints on idle hadrons
+// where no user traffic flows — without this update, the monitor would
+// see zero timestamps and classify the stream as idle instead of stale.
+func TestAGNTKeepalive_UpdatesLastSendUsOnFirstProbe(t *testing.T) {
 	t.Parallel()
 
 	g := newWritePacketTestClient(t, 1)
@@ -2365,11 +2363,10 @@ func TestAGNTKeepalive_DoesNotUpdateLastSendUs(t *testing.T) {
 }
 
 // TestAGNTKeepalive_SendFailure_DoesNotMarkStreamUnhealthy verifies that
-// when an AGNT probe Send() fails, the stream is NOT marked unhealthy.
-// The error is silently discarded.
-//
-// If this test PASSES, the gap exists.
-// If this test FAILS, the gap has been fixed.
+// a single transient Send() failure on an AGNT probe does NOT immediately
+// mark the stream as unhealthy. This is intentional — the liveness monitor
+// detects dead endpoints via stale timestamps (no echo received within
+// staleTimeout), which is more robust than reacting to individual failures.
 func TestAGNTKeepalive_SendFailure_DoesNotMarkStreamUnhealthy(t *testing.T) {
 	t.Parallel()
 

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -754,15 +754,17 @@ func TestSelectStreamForPacket_UnhealthyTunnelsTriggersReconnect(t *testing.T) {
 
 	// Endpoint 0: tunnels exist but ALL unhealthy
 	// Endpoint 1: healthy tunnels (fallback target)
-	g.streamManager.tunnelStreams = make([]*StreamInfo, 4)
+	g.streamManager.tunnelStreams = make([]*StreamInfo, 6)
 	g.streamManager.tunnelStreams[0] = &StreamInfo{connIndex: 0, isHealthy: false, streamID: "s0"}
 	g.streamManager.tunnelStreams[1] = &StreamInfo{connIndex: 0, isHealthy: false, streamID: "s1"}
 	g.streamManager.tunnelStreams[2] = &StreamInfo{connIndex: 1, isHealthy: true, streamID: "s2"}
 	g.streamManager.tunnelStreams[3] = &StreamInfo{connIndex: 1, isHealthy: true, streamID: "s3"}
+	g.streamManager.tunnelStreams[4] = &StreamInfo{connIndex: 2, isHealthy: true, streamID: "s4"}
+	g.streamManager.tunnelStreams[5] = &StreamInfo{connIndex: 2, isHealthy: true, streamID: "s5"}
 
 	g.endpointStreamIndices["grpc://endpoint-0"] = []int{0, 1}
 	g.endpointStreamIndices["grpc://endpoint-1"] = []int{2, 3}
-	g.endpointStreamIndices["grpc://endpoint-2"] = []int{}
+	g.endpointStreamIndices["grpc://endpoint-2"] = []int{4, 5}
 
 	// Force selector to pick endpoint 0 first by pre-binding
 	pkt := make([]byte, 40)
@@ -788,8 +790,8 @@ func TestSelectStreamForPacket_UnhealthyTunnelsTriggersReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected fallback to succeed, got: %v", err)
 	}
-	if stream.connIndex != 1 {
-		t.Fatalf("expected fallback to endpoint 1 (connIndex=1), got connIndex=%d", stream.connIndex)
+	if stream.connIndex == 0 {
+		t.Fatal("expected fallback to a healthy endpoint (not endpoint 0 which has unhealthy tunnels)")
 	}
 
 	// Endpoint 0 should now be marked unhealthy

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1053,7 +1053,7 @@ func (g *GravityClient) startMultiEndpoint() error {
 
 	// Start tunnel liveness monitor after startup succeeds (connected=true).
 	// Starting earlier would leak the goroutine if startup fails.
-	g.logger.Error("DIAG: launching tunnelLivenessMonitor goroutine from startMultiEndpoint")
+	g.logger.Debug("launching tunnelLivenessMonitor goroutine")
 	go g.tunnelLivenessMonitor()
 
 	var endpointURLs []string
@@ -1155,7 +1155,7 @@ func (g *GravityClient) tunnelLivenessMonitor() {
 		staleTimeout  = 30 * time.Second
 	)
 
-	g.logger.Error("DIAG: tunnel liveness monitor started (check=%s, stale=%s)", checkInterval, staleTimeout)
+	g.logger.Debug("tunnel liveness monitor started (check=%s, stale=%s)", checkInterval, staleTimeout)
 
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
@@ -4788,14 +4788,16 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
-				// DIAG: log all endpoint health states
+				// Log endpoint health summary for debugging selector failures.
+				var healthSummary []string
 				for i, ep := range endpoints {
 					if ep != nil {
-						g.logger.Error("DIAG selectStream: endpoint[%d] url=%s healthy=%v", i, ep.URL, ep.healthy.Load())
+						healthSummary = append(healthSummary, fmt.Sprintf("[%d]%s(healthy=%v)", i, ep.URL, ep.healthy.Load()))
 					} else {
-						g.logger.Error("DIAG selectStream: endpoint[%d] is nil", i)
+						healthSummary = append(healthSummary, fmt.Sprintf("[%d]nil", i))
 					}
 				}
+				g.logger.Debug("selectStream: no endpoint selected, health: %s", strings.Join(healthSummary, ", "))
 				return nil, fmt.Errorf("no healthy gravity endpoints")
 			}
 			stream, err := g.selectStreamForEndpoint(payload, endpoint.URL)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -279,20 +279,19 @@ type GravityClient struct {
 	reconnectionFailedCallback func(attempts int, lastErr error)
 
 	// State management
-	connected                bool
-	reconnecting             bool          // Tracks if reconnection is in progress
-	endpointReconnecting     []atomic.Bool // Per-endpoint reconnect guard (multi-endpoint only)
-	consecutiveWriteFailures atomic.Int64  // Counts consecutive WritePacket failures for aggressive recovery
-	connectionIDs            []string      // Stores connection IDs from server responses
-	connectionIDChan         chan string   // Channel to signal when connection ID is received
-	helloAckedStreams        sync.Map      // streamIndex (int) → true: tracks which streams received SessionHelloResponse
-	sessionReady             chan struct{} // Closed when session is fully authenticated and configured
-	otlpURL                  string
-	otlpToken                string
-	apiURL                   string
-	hostMapping              []*pb.HostMapping
-	hostEnvironment          []string
-	once                     sync.Once
+	connected            bool
+	reconnecting         bool          // Tracks if reconnection is in progress
+	endpointReconnecting []atomic.Bool // Per-endpoint reconnect guard (multi-endpoint only)
+	connectionIDs        []string      // Stores connection IDs from server responses
+	connectionIDChan     chan string   // Channel to signal when connection ID is received
+	helloAckedStreams    sync.Map      // streamIndex (int) → true: tracks which streams received SessionHelloResponse
+	sessionReady         chan struct{} // Closed when session is fully authenticated and configured
+	otlpURL              string
+	otlpToken            string
+	apiURL               string
+	hostMapping          []*pb.HostMapping
+	hostEnvironment      []string
+	once                 sync.Once
 
 	// Messaging
 	evacuationCallback    func()
@@ -1133,16 +1132,20 @@ func (g *GravityClient) resolveGravityURLs() []string {
 // half-open streams, or stuck Send/Recv.
 //
 // The keepalive probe ("AGNT" marker) is sent on one stream per endpoint every
-// 15s. Ion echoes it back immediately, updating both LastSendUs and LastRecvUs.
+// 10s. Ion echoes it back immediately, updating LastRecvUs in stream metrics.
 // This keeps idle connections active and provides a positive liveness signal.
+// sendTunnelKeepalives also sets LastSendUs on first probe so streams are
+// promoted from "idle" (zero timestamps) to "probed" — enabling detection
+// of endpoints that die before the first echo arrives.
 //
-// If ALL streams on an endpoint have had activity (non-zero timestamps) but
-// no activity for 60s, the endpoint is marked unhealthy and reconnection is
-// triggered. Streams that have never carried data (idle) are not flagged.
+// If ALL streams on an endpoint have been probed but show no round-trip
+// activity for 30s (~3 missed probes), the endpoint is marked unhealthy
+// and reconnection is triggered. Streams that have never been probed
+// (LastSendUs=0, LastRecvUs=0) are truly idle and not flagged.
 func (g *GravityClient) tunnelLivenessMonitor() {
 	const (
-		checkInterval = 15 * time.Second
-		staleTimeout  = 60 * time.Second
+		checkInterval = 10 * time.Second
+		staleTimeout  = 30 * time.Second
 	)
 
 	ticker := time.NewTicker(checkInterval)
@@ -1243,15 +1246,29 @@ func (g *GravityClient) sendTunnelKeepalives() {
 		// Serialize with the data path's sendMu. Use a goroutine with
 		// timeout so a wedged Send doesn't block the monitor loop.
 		go func(idx int, snap streamSnapshot) {
-			done := make(chan struct{})
+			errCh := make(chan error, 1)
 			go func() {
 				snap.sendMu.Lock()
-				_ = snap.stream.Send(&pb.TunnelPacket{Data: probe})
+				err := snap.stream.Send(&pb.TunnelPacket{Data: probe})
 				snap.sendMu.Unlock()
-				close(done)
+				errCh <- err
 			}()
 			select {
-			case <-done:
+			case err := <-errCh:
+				// Update LastSendUs on first successful probe so the stream
+				// is promoted from "idle" (zero timestamps) to "probed."
+				// Only set once (when LastSendUs==0) so the timestamp
+				// represents "probing since" — if gRPC buffers Sends
+				// locally while the remote is dead, we don't want
+				// LastSendUs refreshed each cycle which would prevent
+				// stale detection.
+				if err == nil {
+					g.streamManager.metricsMu.Lock()
+					if m := g.streamManager.streamMetrics[snap.streamID]; m != nil && m.LastSendUs == 0 {
+						m.LastSendUs = time.Now().UnixMicro()
+					}
+					g.streamManager.metricsMu.Unlock()
+				}
 			case <-time.After(5 * time.Second):
 				g.logger.Warn("tunnel keepalive send blocked >5s on stream %d — possible zombie", idx)
 			}
@@ -1314,18 +1331,28 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 				continue
 			}
 
-			lastActivity := metrics.LastSendUs
-			if metrics.LastRecvUs > lastActivity {
-				lastActivity = metrics.LastRecvUs
+			lastSendUs := metrics.LastSendUs
+			lastRecvUs := metrics.LastRecvUs
+
+			// Truly idle: never probed, never received. This means
+			// sendTunnelKeepalives hasn't run yet (e.g., stream just
+			// established). Don't flag as stale — wait for first probe.
+			if lastSendUs == 0 && lastRecvUs == 0 {
+				allStale = false
+				break
 			}
 
-			// If the stream has never carried data (both timestamps 0),
-			// it's idle — not stale. Only flag as stale if the stream
-			// WAS active (had traffic) and then stopped. This prevents
-			// a reconnection loop on idle hadrons with no containers.
-			if lastActivity == 0 {
-				allStale = false // idle, not stale
-				break
+			// Use LastRecvUs as the primary liveness signal when echoes
+			// have been received — it confirms the remote end is alive.
+			// If we've probed but never received an echo (LastRecvUs==0),
+			// fall back to LastSendUs which represents "probing since."
+			// This covers the case where an ion dies before the first
+			// AGNT echo arrives on an idle hadron.
+			var lastActivity int64
+			if lastRecvUs > 0 {
+				lastActivity = lastRecvUs
+			} else {
+				lastActivity = lastSendUs
 			}
 
 			if (now - lastActivity) < staleUs {
@@ -1346,7 +1373,11 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 			g.logger.Warn("tunnel liveness: endpoint %d (%s) has all stale streams (no activity for %s) — triggering reconnection",
 				connIndex, epURL, staleTimeout)
 			g.wakePeerDiscovery()
-			g.triggerAllEndpointReconnections("tunnel_liveness_stale")
+			// Use per-endpoint reconnection — only reconnect the specific
+			// endpoint with stale streams. Previously this called
+			// triggerAllEndpointReconnections which could cascade a
+			// single-endpoint failure to all endpoints.
+			g.handleEndpointDisconnection(connIndex, "tunnel_liveness_stale")
 			return // One reconnection cycle at a time
 		}
 	}
@@ -3271,10 +3302,14 @@ func (g *GravityClient) triggerEndpointReconnectByURL(url string) {
 	}(idx, url)
 }
 
-// triggerAllEndpointReconnections forces reconnection for every endpoint that
-// isn't already reconnecting. Called when WritePacket fails repeatedly,
-// indicating all endpoints are unhealthy and per-endpoint reconnection alone
-// isn't recovering fast enough.
+// triggerAllEndpointReconnections forces reconnection for every unhealthy
+// endpoint that isn't already reconnecting. Healthy endpoints are skipped to
+// prevent a single-endpoint failure from cascading to all endpoints.
+//
+// Called when WritePacket fails repeatedly or the tunnel liveness monitor
+// detects stale streams. The healthy-endpoint check acts as a safety net:
+// callers should ideally target specific endpoints, but if they invoke this
+// function, only genuinely broken endpoints will be disrupted.
 func (g *GravityClient) triggerAllEndpointReconnections(reason string) {
 	g.mu.RLock()
 	if g.closing {
@@ -3283,12 +3318,34 @@ func (g *GravityClient) triggerAllEndpointReconnections(reason string) {
 	}
 	g.mu.RUnlock()
 
+	g.endpointsMu.RLock()
+	endpoints := g.endpoints
+	g.endpointsMu.RUnlock()
+
+	reconnected := 0
+	skipped := 0
 	for i := range g.endpointReconnecting {
+		// Safety net: skip endpoints that are still healthy. This prevents a
+		// single-endpoint failure from cascading to all endpoints — the root
+		// cause of total outage when one ion dies while others are fine.
+		if i < len(endpoints) && endpoints[i] != nil && endpoints[i].healthy.Load() {
+			skipped++
+			g.logger.Debug("aggressive reconnect: skipping healthy endpoint %d (%s)", i, reason)
+			continue
+		}
 		if g.endpointReconnecting[i].CompareAndSwap(false, true) {
-			g.logger.Info("aggressive reconnect: triggering endpoint %d reconnection (%s)", i, reason)
+			reconnected++
+			var epURL string
+			if i < len(endpoints) && endpoints[i] != nil {
+				epURL = endpoints[i].URL
+			}
+			g.logger.Info("aggressive reconnect: triggering endpoint %d (%s) reconnection (%s)", i, epURL, reason)
 			g.disconnectEndpointStreams(i)
 			go g.reconnectEndpoint(i, reason)
 		}
+	}
+	if skipped > 0 {
+		g.logger.Info("aggressive reconnect: skipped %d healthy endpoint(s), reconnected %d (%s)", skipped, reconnected, reason)
 	}
 }
 
@@ -4580,14 +4637,13 @@ func (g *GravityClient) WritePacket(payload []byte) error {
 	// Multi-endpoint routing: sticky flow binding to selected endpoint.
 	if stream, err := g.selectStreamForPacket(payload); err != nil {
 		g.logger.Error("writePacket failed to select stream: %v", err)
-		// Track consecutive write failures. When all endpoints are unhealthy,
-		// aggressively trigger reconnection for every endpoint that isn't
-		// already reconnecting, and wake peer discovery to re-resolve DNS.
-		if failures := g.consecutiveWriteFailures.Add(1); failures == 1 || failures%10 == 0 {
-			g.logger.Warn("triggering aggressive reconnection after %d consecutive write failure(s)", failures)
-			g.wakePeerDiscovery()
-			g.triggerAllEndpointReconnections("consecutive_write_failures")
-		}
+		// Do NOT trigger reconnection here. selectStreamForPacket already
+		// handles per-endpoint reconnection internally: when all streams for
+		// an endpoint are unhealthy, it marks the endpoint unhealthy and calls
+		// triggerEndpointReconnectByURL. The tunnel liveness monitor (AGNT
+		// keepalive) provides the authoritative signal for dead endpoints.
+		// Reacting to individual packet failures caused false-positive
+		// cascading reconnection that killed healthy endpoints.
 		return err
 	} else {
 		if g.tracePackets {
@@ -4630,16 +4686,14 @@ func (g *GravityClient) WritePacket(payload []byte) error {
 				return nil
 			}
 			g.logger.Error("writePacket stream.Send failed: %v", err)
-			// Send errors are just as indicative of a broken connection as
-			// stream selection failures — increment the counter for both.
-			if failures := g.consecutiveWriteFailures.Add(1); failures == 1 || failures%10 == 0 {
-				g.logger.Warn("triggering aggressive reconnection after %d consecutive write failure(s) (send error)", failures)
-				g.wakePeerDiscovery()
-				g.triggerAllEndpointReconnections("consecutive_send_failures")
-			}
+			// Do NOT trigger reconnection from Send failures. A single bad
+			// packet (TCP retransmit, transient buffer pressure) must not
+			// flap the connection. The stream is already marked unhealthy
+			// above, so selectStreamForPacket will route future packets to
+			// other streams/endpoints. The tunnel liveness monitor (AGNT
+			// keepalive echo) is the authoritative signal for dead endpoints
+			// and will trigger per-endpoint reconnection when appropriate.
 		} else {
-			// Reset consecutive failure counter on successful write
-			g.consecutiveWriteFailures.Store(0)
 			if g.tracePackets {
 				g.tracePacketLogger.Debug("writePacket stream.Send succeeded for stream %s", stream.streamID)
 			}

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1053,6 +1053,7 @@ func (g *GravityClient) startMultiEndpoint() error {
 
 	// Start tunnel liveness monitor after startup succeeds (connected=true).
 	// Starting earlier would leak the goroutine if startup fails.
+	g.logger.Error("DIAG: launching tunnelLivenessMonitor goroutine from startMultiEndpoint")
 	go g.tunnelLivenessMonitor()
 
 	var endpointURLs []string
@@ -1143,10 +1144,18 @@ func (g *GravityClient) resolveGravityURLs() []string {
 // and reconnection is triggered. Streams that have never been probed
 // (LastSendUs=0, LastRecvUs=0) are truly idle and not flagged.
 func (g *GravityClient) tunnelLivenessMonitor() {
+	defer func() {
+		if r := recover(); r != nil {
+			g.logger.Error("tunnel liveness monitor PANICKED: %v", r)
+		}
+	}()
+
 	const (
 		checkInterval = 10 * time.Second
 		staleTimeout  = 30 * time.Second
 	)
+
+	g.logger.Error("DIAG: tunnel liveness monitor started (check=%s, stale=%s)", checkInterval, staleTimeout)
 
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
@@ -1154,6 +1163,7 @@ func (g *GravityClient) tunnelLivenessMonitor() {
 	for {
 		select {
 		case <-g.ctx.Done():
+			g.logger.Debug("tunnel liveness monitor exiting (context cancelled)")
 			return
 		case <-ticker.C:
 			g.sendTunnelKeepalives()
@@ -1177,6 +1187,7 @@ type streamSnapshot struct {
 }
 
 func (g *GravityClient) sendTunnelKeepalives() {
+	g.logger.Trace("tunnel keepalive: starting probe cycle")
 	// Snapshot stream info under tunnelMu to avoid data races on isHealthy.
 	g.streamManager.tunnelMu.RLock()
 	snapshots := make([]streamSnapshot, len(g.streamManager.tunnelStreams))
@@ -1574,13 +1585,27 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 		return
 	}
 
+	// Priority 2: if below capacity, add new endpoints immediately — don't
+	// wait for the cycle interval. This ensures newly discovered ions are
+	// connected to as soon as DNS returns their IP.
+	if currentCount < maxPeers && len(newURLs) > 0 {
+		newURL := pickRandomURL(newURLs)
+		if newURL != "" {
+			g.logger.Info("peer discovery: adding new endpoint %s (currently %d/%d, %d new available)",
+				newURL, currentCount, maxPeers, len(newURLs))
+			g.addEndpoint(newURL)
+			return
+		}
+	}
+
+	// Priority 3: rotate one connection for freshness (cycle interval gated).
 	now := time.Now()
 	lastCycleUnix := g.lastCycleTime.Load()
 	if lastCycleUnix > 0 {
 		lastCycle := time.Unix(lastCycleUnix, 0)
 		if now.Sub(lastCycle) < cycleInterval {
-			g.logger.Debug("peer discovery: %d new URLs available but cycle interval not reached (last cycle: %s ago)",
-				len(newURLs), now.Sub(lastCycle).Round(time.Minute))
+			g.logger.Debug("peer discovery: at capacity (%d/%d), cycle interval not reached (last cycle: %s ago)",
+				currentCount, maxPeers, now.Sub(lastCycle).Round(time.Minute))
 			return
 		}
 	}
@@ -1635,6 +1660,44 @@ func (g *GravityClient) cycleEndpoint(oldURL, newURL string) {
 
 	g.logger.Info("peer discovery: endpoint cycled: removed %s, added %s", oldURL, newURL)
 	g.logger.Debug("peer discovery: new endpoint %s will connect on next connection attempt", newURL)
+}
+
+// addEndpoint adds a new endpoint to an empty slot (nil or empty URL) in
+// the endpoints slice. Used by peer discovery to connect to newly discovered
+// gravity servers without waiting for the cycle interval.
+func (g *GravityClient) addEndpoint(newURL string) {
+	if strings.TrimSpace(newURL) == "" {
+		return
+	}
+
+	g.endpointsMu.Lock()
+	slotIdx := -1
+	for i, ep := range g.endpoints {
+		if ep == nil || strings.TrimSpace(ep.URL) == "" {
+			slotIdx = i
+			break
+		}
+	}
+	if slotIdx < 0 {
+		g.endpointsMu.Unlock()
+		g.logger.Debug("peer discovery: no empty slot for new endpoint %s", newURL)
+		return
+	}
+
+	newEp := &GravityEndpoint{URL: newURL}
+	newEp.healthy.Store(false) // will become healthy after reconnection
+	g.endpoints[slotIdx] = newEp
+	g.endpointsMu.Unlock()
+
+	// Update connection URL mapping for the new endpoint.
+	g.mu.Lock()
+	if slotIdx < len(g.connectionURLs) {
+		g.connectionURLs[slotIdx] = newURL
+	}
+	g.mu.Unlock()
+
+	g.logger.Info("peer discovery: added new endpoint %s at slot %d, starting reconnection", newURL, slotIdx)
+	go g.reconnectEndpoint(slotIdx, "peer_discovery_add")
 }
 
 func pickRandomURL(urls []string) string {
@@ -4725,6 +4788,14 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
+				// DIAG: log all endpoint health states
+				for i, ep := range endpoints {
+					if ep != nil {
+						g.logger.Error("DIAG selectStream: endpoint[%d] url=%s healthy=%v", i, ep.URL, ep.healthy.Load())
+					} else {
+						g.logger.Error("DIAG selectStream: endpoint[%d] is nil", i)
+					}
+				}
 				return nil, fmt.Errorf("no healthy gravity endpoints")
 			}
 			stream, err := g.selectStreamForEndpoint(payload, endpoint.URL)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -413,6 +413,7 @@ type StreamMetrics struct {
 	LastError       time.Time
 	LastSendUs      int64 // unix microseconds of last successful send
 	LastRecvUs      int64 // unix microseconds of last successful receive
+	LastProbeSentUs int64 // unix microseconds of last keepalive probe sent (probe-only, not data traffic)
 }
 
 // New creates a new gRPC-based Gravity server client
@@ -1135,14 +1136,16 @@ func (g *GravityClient) resolveGravityURLs() []string {
 // The keepalive probe ("AGNT" marker) is sent on one stream per endpoint every
 // 10s. Ion echoes it back immediately, updating LastRecvUs in stream metrics.
 // This keeps idle connections active and provides a positive liveness signal.
-// sendTunnelKeepalives also sets LastSendUs on first probe so streams are
+// sendTunnelKeepalives also sets LastProbeSentUs on every probe so streams are
 // promoted from "idle" (zero timestamps) to "probed" — enabling detection
-// of endpoints that die before the first echo arrives.
+// of endpoints that die before the first echo arrives. LastProbeSentUs is
+// separate from LastSendUs (updated by normal data traffic) to prevent
+// WritePacket sends from masking zombie tunnels.
 //
 // If ALL streams on an endpoint have been probed but show no round-trip
 // activity for 30s (~3 missed probes), the endpoint is marked unhealthy
 // and reconnection is triggered. Streams that have never been probed
-// (LastSendUs=0, LastRecvUs=0) are truly idle and not flagged.
+// (LastProbeSentUs=0, LastRecvUs=0) are truly idle and not flagged.
 func (g *GravityClient) tunnelLivenessMonitor() {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1266,17 +1269,17 @@ func (g *GravityClient) sendTunnelKeepalives() {
 			}()
 			select {
 			case err := <-errCh:
-				// Update LastSendUs on first successful probe so the stream
-				// is promoted from "idle" (zero timestamps) to "probed."
-				// Only set once (when LastSendUs==0) so the timestamp
-				// represents "probing since" — if gRPC buffers Sends
-				// locally while the remote is dead, we don't want
-				// LastSendUs refreshed each cycle which would prevent
-				// stale detection.
+				// Update LastProbeSentUs on every successful probe so the
+				// liveness monitor can distinguish "probed but no echo"
+				// from "never probed." Unlike LastSendUs (updated by
+				// normal WritePacket traffic), LastProbeSentUs is only
+				// set by keepalive probes — preventing data-path sends
+				// from masking a zombie tunnel (one-way: sending works,
+				// receiving doesn't).
 				if err == nil {
 					g.streamManager.metricsMu.Lock()
-					if m := g.streamManager.streamMetrics[snap.streamID]; m != nil && m.LastSendUs == 0 {
-						m.LastSendUs = time.Now().UnixMicro()
+					if m := g.streamManager.streamMetrics[snap.streamID]; m != nil {
+						m.LastProbeSentUs = time.Now().UnixMicro()
 					}
 					g.streamManager.metricsMu.Unlock()
 				}
@@ -1342,13 +1345,12 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 				continue
 			}
 
-			lastSendUs := metrics.LastSendUs
 			lastRecvUs := metrics.LastRecvUs
 
 			// Truly idle: never probed, never received. This means
 			// sendTunnelKeepalives hasn't run yet (e.g., stream just
 			// established). Don't flag as stale — wait for first probe.
-			if lastSendUs == 0 && lastRecvUs == 0 {
+			if metrics.LastProbeSentUs == 0 && lastRecvUs == 0 {
 				allStale = false
 				break
 			}
@@ -1356,14 +1358,15 @@ func (g *GravityClient) checkTunnelStreamLiveness(staleTimeout time.Duration) {
 			// Use LastRecvUs as the primary liveness signal when echoes
 			// have been received — it confirms the remote end is alive.
 			// If we've probed but never received an echo (LastRecvUs==0),
-			// fall back to LastSendUs which represents "probing since."
-			// This covers the case where an ion dies before the first
-			// AGNT echo arrives on an idle hadron.
+			// fall back to LastProbeSentUs which represents "probing since."
+			// Using LastProbeSentUs (not LastSendUs) avoids masking zombie
+			// tunnels — normal WritePacket traffic updates LastSendUs, which
+			// can hide a one-way tunnel where sending works but receiving doesn't.
 			var lastActivity int64
 			if lastRecvUs > 0 {
 				lastActivity = lastRecvUs
 			} else {
-				lastActivity = lastSendUs
+				lastActivity = metrics.LastProbeSentUs
 			}
 
 			if (now - lastActivity) < staleUs {
@@ -1679,9 +1682,21 @@ func (g *GravityClient) addEndpoint(newURL string) {
 		}
 	}
 	if slotIdx < 0 {
-		g.endpointsMu.Unlock()
-		g.logger.Debug("peer discovery: no empty slot for new endpoint %s", newURL)
-		return
+		// No empty slot found. If we haven't reached maxPeers, grow
+		// the endpoints slice (startup may have discovered fewer peers
+		// than the configured maximum).
+		maxPeers := g.poolConfig.MaxGravityPeers
+		if maxPeers <= 0 {
+			maxPeers = DefaultMaxGravityPeers
+		}
+		if len(g.endpoints) < maxPeers {
+			slotIdx = len(g.endpoints)
+			g.endpoints = append(g.endpoints, nil) // will be set below
+		} else {
+			g.endpointsMu.Unlock()
+			g.logger.Debug("peer discovery: no empty slot for new endpoint %s (at max %d peers)", newURL, maxPeers)
+			return
+		}
 	}
 
 	newEp := &GravityEndpoint{URL: newURL}
@@ -1689,12 +1704,49 @@ func (g *GravityClient) addEndpoint(newURL string) {
 	g.endpoints[slotIdx] = newEp
 	g.endpointsMu.Unlock()
 
-	// Update connection URL mapping for the new endpoint.
+	// Grow all parallel arrays indexed by endpoint index so that
+	// reconnectEndpoint and other code paths can safely access [slotIdx].
+	// This mirrors the initialization in startMultiEndpoint.
 	g.mu.Lock()
-	if slotIdx < len(g.connectionURLs) {
-		g.connectionURLs[slotIdx] = newURL
+	for len(g.connectionURLs) <= slotIdx {
+		g.connectionURLs = append(g.connectionURLs, "")
+	}
+	g.connectionURLs[slotIdx] = newURL
+	for len(g.connections) <= slotIdx {
+		g.connections = append(g.connections, nil)
+	}
+	for len(g.sessionClients) <= slotIdx {
+		g.sessionClients = append(g.sessionClients, nil)
+	}
+	for len(g.circuitBreakers) <= slotIdx {
+		g.circuitBreakers = append(g.circuitBreakers, nil)
+	}
+	for len(g.endpointReconnecting) <= slotIdx {
+		g.endpointReconnecting = append(g.endpointReconnecting, atomic.Bool{})
 	}
 	g.mu.Unlock()
+
+	// Grow stream manager arrays under their respective locks.
+	g.streamManager.controlMu.Lock()
+	for len(g.streamManager.controlStreams) <= slotIdx {
+		g.streamManager.controlStreams = append(g.streamManager.controlStreams, nil)
+	}
+	for len(g.streamManager.controlSendMu) <= slotIdx {
+		g.streamManager.controlSendMu = append(g.streamManager.controlSendMu, sync.Mutex{})
+	}
+	for len(g.streamManager.contexts) <= slotIdx {
+		g.streamManager.contexts = append(g.streamManager.contexts, nil)
+	}
+	for len(g.streamManager.cancels) <= slotIdx {
+		g.streamManager.cancels = append(g.streamManager.cancels, nil)
+	}
+	g.streamManager.controlMu.Unlock()
+
+	g.streamManager.healthMu.Lock()
+	for len(g.streamManager.connectionHealth) <= slotIdx {
+		g.streamManager.connectionHealth = append(g.streamManager.connectionHealth, false)
+	}
+	g.streamManager.healthMu.Unlock()
 
 	g.logger.Info("peer discovery: added new endpoint %s at slot %d, starting reconnection", newURL, slotIdx)
 	go g.reconnectEndpoint(slotIdx, "peer_discovery_add")
@@ -3381,8 +3433,21 @@ func (g *GravityClient) triggerAllEndpointReconnections(reason string) {
 	}
 	g.mu.RUnlock()
 
+	// Snapshot endpoint URL and health state while holding the lock. The
+	// slice header copy (endpoints = g.endpoints) is safe for the header
+	// itself, but entries can be mutated by other goroutines after release.
+	// Copying into a local struct slice avoids reading stale/torn values.
+	type epSnapshot struct {
+		url     string
+		healthy bool
+	}
 	g.endpointsMu.RLock()
-	endpoints := g.endpoints
+	snapshots := make([]epSnapshot, len(g.endpoints))
+	for i, ep := range g.endpoints {
+		if ep != nil {
+			snapshots[i] = epSnapshot{url: ep.URL, healthy: ep.healthy.Load()}
+		}
+	}
 	g.endpointsMu.RUnlock()
 
 	reconnected := 0
@@ -3391,7 +3456,7 @@ func (g *GravityClient) triggerAllEndpointReconnections(reason string) {
 		// Safety net: skip endpoints that are still healthy. This prevents a
 		// single-endpoint failure from cascading to all endpoints — the root
 		// cause of total outage when one ion dies while others are fine.
-		if i < len(endpoints) && endpoints[i] != nil && endpoints[i].healthy.Load() {
+		if i < len(snapshots) && snapshots[i].healthy {
 			skipped++
 			g.logger.Debug("aggressive reconnect: skipping healthy endpoint %d (%s)", i, reason)
 			continue
@@ -3399,8 +3464,8 @@ func (g *GravityClient) triggerAllEndpointReconnections(reason string) {
 		if g.endpointReconnecting[i].CompareAndSwap(false, true) {
 			reconnected++
 			var epURL string
-			if i < len(endpoints) && endpoints[i] != nil {
-				epURL = endpoints[i].URL
+			if i < len(snapshots) {
+				epURL = snapshots[i].url
 			}
 			g.logger.Info("aggressive reconnect: triggering endpoint %d (%s) reconnection (%s)", i, epURL, reason)
 			g.disconnectEndpointStreams(i)

--- a/gravity/tunnel_selector.go
+++ b/gravity/tunnel_selector.go
@@ -66,14 +66,10 @@ func (s *EndpointSelector) Select(packet []byte, endpoints []*GravityEndpoint) *
 				return current.Endpoint
 			}
 			s.mu.Unlock()
-		} else if binding.IsReturn {
-			// Return traffic (response to inbound) with unhealthy originator:
-			// routing to a different endpoint won't help — it doesn't have the
-			// NAT/conntrack entry. Drop the packet; the TCP connection is already
-			// broken and the client will retry through a healthy endpoint.
-			return nil
 		}
-		// Forward flow with unhealthy endpoint: fall through to pick a new one.
+		// Unhealthy endpoint (forward or return flow): fall through to pick
+		// a healthy one. With any-to-any NAT, return traffic can be routed
+		// through a different endpoint.
 	}
 
 	// Slow path: pick new endpoint, store binding.

--- a/gravity/tunnel_selector_test.go
+++ b/gravity/tunnel_selector_test.go
@@ -316,10 +316,11 @@ func TestRecordInboundFlow_MultipleFlows(t *testing.T) {
 	}
 }
 
-// TestRecordInboundFlow_UnhealthyDrops verifies that return traffic is dropped
-// (nil) when the originating endpoint is unhealthy, rather than misrouting to
-// a different endpoint that doesn't have the NAT/conntrack entry.
-func TestRecordInboundFlow_UnhealthyDrops(t *testing.T) {
+// TestRecordInboundFlow_UnhealthyFailsOver verifies that return traffic
+// fails over to a healthy endpoint when the originating endpoint goes down.
+// With any-to-any NAT, the NAT entry is shared across ions, so the return
+// flow can safely be routed to any healthy endpoint.
+func TestRecordInboundFlow_UnhealthyFailsOver(t *testing.T) {
 	t.Parallel()
 
 	selector := NewEndpointSelector(time.Minute)

--- a/gravity/tunnel_selector_test.go
+++ b/gravity/tunnel_selector_test.go
@@ -338,11 +338,15 @@ func TestRecordInboundFlow_UnhealthyDrops(t *testing.T) {
 	// Mark ep1 as unhealthy (tunnel went down)
 	ep1.healthy.Store(false)
 
-	// Response should be nil (dropped), NOT routed to ep2
+	// With any-to-any NAT, return traffic should failover to ep2
+	// (not be dropped). The NAT entry is shared across ions.
 	response := makeIPv6TCPPacket(containerIP, ionIP, 443, 33628)
 	selected := selector.Select(response, endpoints)
-	if selected != nil {
-		t.Fatalf("expected nil (drop) for return traffic with unhealthy originator, got %s", selected.URL)
+	if selected == nil {
+		t.Fatal("expected return flow to failover to healthy endpoint, got nil")
+	}
+	if selected != ep2 {
+		t.Fatalf("expected failover to ep2, got %s", selected.URL)
 	}
 }
 
@@ -395,5 +399,43 @@ func TestRecordInboundFlow_NilEndpoint(t *testing.T) {
 
 	if selector.Len() != 0 {
 		t.Fatal("expected no binding for nil endpoint")
+	}
+}
+
+// TestRecordInboundFlow_ReturnFlowFailsOverWithAnyToAnyNAT verifies that
+// return traffic (response to inbound) falls over to a healthy endpoint
+// when the original endpoint is unhealthy. With any-to-any NAT, the NAT
+// entry is shared across ions, so return traffic CAN be routed through a
+// different endpoint.
+//
+// This test FAILS before the fix (selector returns nil) and PASSES after.
+func TestRecordInboundFlow_ReturnFlowFailsOverWithAnyToAnyNAT(t *testing.T) {
+	t.Parallel()
+
+	selector := NewEndpointSelector(time.Minute)
+	ep1 := &GravityEndpoint{URL: "grpc://ion-1:443"}
+	ep2 := &GravityEndpoint{URL: "grpc://ion-2:444"}
+	ep1.healthy.Store(true)
+	ep2.healthy.Store(true)
+	endpoints := []*GravityEndpoint{ep1, ep2}
+
+	ionIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	containerIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+
+	// Record inbound flow from ep1
+	selector.RecordInboundFlow(makeIPv6TCPPacket(ionIP, containerIP, 33628, 443), ep1)
+
+	// Mark ep1 as unhealthy (ion went down)
+	ep1.healthy.Store(false)
+
+	// Response should failover to ep2, NOT return nil.
+	// With any-to-any NAT, another ion can handle the return traffic.
+	response := makeIPv6TCPPacket(containerIP, ionIP, 443, 33628)
+	selected := selector.Select(response, endpoints)
+	if selected == nil {
+		t.Fatal("expected return flow to failover to healthy endpoint with any-to-any NAT, got nil (drop)")
+	}
+	if selected != ep2 {
+		t.Fatalf("expected failover to ep2, got %s", selected.URL)
 	}
 }

--- a/gravity/tunnel_selector_test.go
+++ b/gravity/tunnel_selector_test.go
@@ -317,37 +317,60 @@ func TestRecordInboundFlow_MultipleFlows(t *testing.T) {
 }
 
 // TestRecordInboundFlow_UnhealthyFailsOver verifies that return traffic
-// fails over to a healthy endpoint when the originating endpoint goes down.
-// With any-to-any NAT, the NAT entry is shared across ions, so the return
-// flow can safely be routed to any healthy endpoint.
+// (response to inbound) fails over to a healthy endpoint when the originating
+// endpoint goes down. With any-to-any NAT, the NAT entry is shared across
+// ions, so return traffic CAN be routed through a different endpoint.
+//
+// This is a table-driven test covering both the basic failover case and the
+// explicit any-to-any NAT scenario (which are functionally equivalent).
 func TestRecordInboundFlow_UnhealthyFailsOver(t *testing.T) {
 	t.Parallel()
 
-	selector := NewEndpointSelector(time.Minute)
-	ep1 := &GravityEndpoint{URL: "grpc://ion-1:443"}
-	ep2 := &GravityEndpoint{URL: "grpc://ion-2:444"}
-	ep1.healthy.Store(true)
-	ep2.healthy.Store(true)
-	endpoints := []*GravityEndpoint{ep1, ep2}
-
-	ionIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
-	containerIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
-
-	// Record inbound flow from ep1
-	selector.RecordInboundFlow(makeIPv6TCPPacket(ionIP, containerIP, 33628, 443), ep1)
-
-	// Mark ep1 as unhealthy (tunnel went down)
-	ep1.healthy.Store(false)
-
-	// With any-to-any NAT, return traffic should failover to ep2
-	// (not be dropped). The NAT entry is shared across ions.
-	response := makeIPv6TCPPacket(containerIP, ionIP, 443, 33628)
-	selected := selector.Select(response, endpoints)
-	if selected == nil {
-		t.Fatal("expected return flow to failover to healthy endpoint, got nil")
+	tests := []struct {
+		name    string
+		comment string // for clarity in sub-test descriptions
+	}{
+		{
+			name:    "return_flow_failover",
+			comment: "basic return traffic failover when originating endpoint is unhealthy",
+		},
+		{
+			name:    "any_to_any_NAT",
+			comment: "with any-to-any NAT, another ion can handle the return traffic",
+		},
 	}
-	if selected != ep2 {
-		t.Fatalf("expected failover to ep2, got %s", selected.URL)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			selector := NewEndpointSelector(time.Minute)
+			ep1 := &GravityEndpoint{URL: "grpc://ion-1:443"}
+			ep2 := &GravityEndpoint{URL: "grpc://ion-2:444"}
+			ep1.healthy.Store(true)
+			ep2.healthy.Store(true)
+			endpoints := []*GravityEndpoint{ep1, ep2}
+
+			ionIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+			containerIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+
+			// Record inbound flow from ep1
+			selector.RecordInboundFlow(makeIPv6TCPPacket(ionIP, containerIP, 33628, 443), ep1)
+
+			// Mark ep1 as unhealthy (ion/tunnel went down)
+			ep1.healthy.Store(false)
+
+			// Return traffic should failover to ep2, NOT return nil.
+			// The NAT entry is shared across ions.
+			response := makeIPv6TCPPacket(containerIP, ionIP, 443, 33628)
+			selected := selector.Select(response, endpoints)
+			if selected == nil {
+				t.Fatalf("[%s] expected return flow to failover to healthy endpoint, got nil (drop)", tt.comment)
+			}
+			if selected != ep2 {
+				t.Fatalf("[%s] expected failover to ep2, got %s", tt.comment, selected.URL)
+			}
+		})
 	}
 }
 
@@ -400,43 +423,5 @@ func TestRecordInboundFlow_NilEndpoint(t *testing.T) {
 
 	if selector.Len() != 0 {
 		t.Fatal("expected no binding for nil endpoint")
-	}
-}
-
-// TestRecordInboundFlow_ReturnFlowFailsOverWithAnyToAnyNAT verifies that
-// return traffic (response to inbound) falls over to a healthy endpoint
-// when the original endpoint is unhealthy. With any-to-any NAT, the NAT
-// entry is shared across ions, so return traffic CAN be routed through a
-// different endpoint.
-//
-// This test FAILS before the fix (selector returns nil) and PASSES after.
-func TestRecordInboundFlow_ReturnFlowFailsOverWithAnyToAnyNAT(t *testing.T) {
-	t.Parallel()
-
-	selector := NewEndpointSelector(time.Minute)
-	ep1 := &GravityEndpoint{URL: "grpc://ion-1:443"}
-	ep2 := &GravityEndpoint{URL: "grpc://ion-2:444"}
-	ep1.healthy.Store(true)
-	ep2.healthy.Store(true)
-	endpoints := []*GravityEndpoint{ep1, ep2}
-
-	ionIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
-	containerIP := [16]byte{0xfd, 0x15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
-
-	// Record inbound flow from ep1
-	selector.RecordInboundFlow(makeIPv6TCPPacket(ionIP, containerIP, 33628, 443), ep1)
-
-	// Mark ep1 as unhealthy (ion went down)
-	ep1.healthy.Store(false)
-
-	// Response should failover to ep2, NOT return nil.
-	// With any-to-any NAT, another ion can handle the return traffic.
-	response := makeIPv6TCPPacket(containerIP, ionIP, 443, 33628)
-	selected := selector.Select(response, endpoints)
-	if selected == nil {
-		t.Fatal("expected return flow to failover to healthy endpoint with any-to-any NAT, got nil (drop)")
-	}
-	if selected != ep2 {
-		t.Fatalf("expected failover to ep2, got %s", selected.URL)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a production outage scenario where one ion dying killed ALL hadron tunnel connections, causing total connectivity loss. This PR contains multiple fixes that together enable zero-downtime ion cycling.

## Changes

### 1. Remove cascading reconnection from WritePacket
- Removed global `consecutiveWriteFailures` counter that triggered `triggerAllEndpointReconnections` on a single Send failure
- A single bad packet (transient TCP issue, buffer pressure) no longer flaps the entire connection
- Streams are marked unhealthy; the pool routes around them
- The tunnel liveness monitor (AGNT keepalive) is now the authoritative signal for dead endpoints

### 2. Per-endpoint tunnel liveness
- Tunnel liveness monitor now uses `handleEndpointDisconnection` (per-endpoint) instead of `triggerAllEndpointReconnections` (global cascade risk)
- Safety net in `triggerAllEndpointReconnections`: skips healthy endpoints (zero production callers, defense-in-depth)

### 3. AGNT keepalive improvements
- `sendTunnelKeepalives` updates `LastSendUs` on first probe, promoting streams from "idle" to "probed"
- Liveness check uses `LastRecvUs` as primary stale signal; falls back to `LastSendUs` for "probed but no echo"
- Timing: checkInterval 15s→10s, staleTimeout 60s→30s (3 missed probes, faster detection)

### 4. Return flow failover with any-to-any NAT
- `EndpointSelector.Select` now fails over return flows to healthy endpoints instead of dropping them
- Previously, return traffic bound to an unhealthy endpoint returned nil, killing ALL tunnel traffic when one ion died
- With any-to-any NAT, return traffic can route through any ion

### 5. Peer discovery: immediate new endpoint connection
- New endpoints are connected immediately when below capacity (`currentCount < maxPeers`)
- Previously waited for the 2-hour cycle interval before connecting to newly discovered ions
- `addEndpoint` finds an empty slot and triggers background reconnection

## Test Coverage
- 30+ new tests covering cascade prevention, WritePacket integration, liveness detection, AGNT keepalive, selector failover
- All tests pass with `-race`

## Production Validation
- Tested on test-gravity cluster with 3 ions + 1 hadron
- Graceful ion cycling: 299/300 requests succeeded (one connection reset) across all 3 ion cycles
- Zero timeouts, zero 503s during graceful failover
- Hadron correctly enters degraded mode (2/3) and recovers to 3/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cascading reconnections so an unhealthy endpoint no longer forces healthy peers to reconnect.
  * Writes no longer trigger aggressive reconnection; failures isolate to affected streams and avoid disrupting healthy endpoints.
  * Return traffic now fails over to healthy endpoints instead of being dropped when the original endpoint becomes unhealthy.
  * Improved tunnel liveness handling to prefer echo-confirmed activity when deciding staleness.

* **New Features**
  * Faster peer discovery: newly found peers can be added immediately when capacity allows.
  * Keepalive probe tracking added to metrics and probe cadence/timings adjusted for quicker detection.

* **Tests**
  * Added extensive tests covering reconnection isolation, per-endpoint liveness, write-path behavior, failover, keepalive probes, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->