### PR TITLE
feat(dns): add Catalyst HTTP API transport support

### DIFF
--- a/dns/aether.go
+++ b/dns/aether.go
@@ -1,13 +1,17 @@
 package dns
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/agentuity/go-common/api"
 	cstr "github.com/agentuity/go-common/string"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -225,12 +229,16 @@ type Subscriber interface {
 }
 
 type option struct {
-	transport Transport
-	timeout   time.Duration
-	reply     bool
+	transport      Transport
+	catalystClient *catalystClient
+	timeout        time.Duration
+	reply          bool
 }
 
-type optionHandler func(*option)
+// OptionHandler is a function that configures DNS action options.
+type OptionHandler func(*option)
+
+type optionHandler = OptionHandler
 
 // WithReply sets whether the DNS action should wait for a reply from the DNS server
 func WithReply(reply bool) optionHandler {
@@ -258,6 +266,83 @@ func WithRedis(redis *redis.Client) optionHandler {
 	return func(o *option) {
 		o.transport = &redisTransport{redis: redis}
 	}
+}
+
+// WithCatalyst uses the Catalyst HTTP API for DNS operations.
+// apiURL is the base URL of the catalyst server (e.g., "https://catalyst.agentuity.cloud")
+// token is the aether API token (ak_ prefix) for authentication
+func WithCatalyst(apiURL, token string) optionHandler {
+	return func(o *option) {
+		o.catalystClient = &catalystClient{
+			baseURL: strings.TrimSuffix(apiURL, "/"),
+			token:   token,
+			client: &http.Client{
+				Timeout: 30 * time.Second,
+			},
+		}
+	}
+}
+
+// WithCatalystClient uses a custom HTTP client with the Catalyst API.
+func WithCatalystClient(apiURL, token string, httpClient *http.Client) optionHandler {
+	return func(o *option) {
+		o.catalystClient = &catalystClient{
+			baseURL: strings.TrimSuffix(apiURL, "/"),
+			token:   token,
+			client:  httpClient,
+		}
+	}
+}
+
+type catalystClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func (c *catalystClient) do(ctx context.Context, action string, reqBody interface{}, respBody interface{}) error {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := c.baseURL + "/aether/dns/" + action
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("User-Agent", api.UserAgent())
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(respBodyBytes, &errResp) == nil && errResp.Error != "" {
+			return errors.New(errResp.Error)
+		}
+		return fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBodyBytes))
+	}
+
+	if err := json.Unmarshal(respBodyBytes, respBody); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return nil
 }
 
 type redisSubscriber struct {
@@ -341,6 +426,11 @@ func SendDNSAction[R any, T TypedDNSAction[R]](ctx context.Context, action T, op
 		opt(&o)
 	}
 
+	// Use Catalyst HTTP API if configured
+	if o.catalystClient != nil {
+		return sendViaCatalyst(ctx, o.catalystClient, action, o.timeout)
+	}
+
 	if o.transport == nil {
 		return nil, ErrTransportRequired
 	}
@@ -384,4 +474,63 @@ func SendDNSAction[R any, T TypedDNSAction[R]](ctx context.Context, action T, op
 	}
 
 	return nil, nil
+}
+
+func sendViaCatalyst[R any, T TypedDNSAction[R]](ctx context.Context, client *catalystClient, action T, timeout time.Duration) (*R, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	switch a := any(action).(type) {
+	case *DNSAddAction:
+		var resp struct {
+			IDs []string `json:"ids"`
+		}
+		req := map[string]interface{}{
+			"name":  a.Name,
+			"type":  a.Type,
+			"value": a.Value,
+		}
+		if a.TTL > 0 {
+			req["ttl"] = int(a.TTL.Seconds())
+		}
+		if a.Expires > 0 {
+			req["expires"] = int(a.Expires.Seconds())
+		}
+		if a.Priority > 0 {
+			req["priority"] = a.Priority
+		}
+		if a.Weight > 0 {
+			req["weight"] = a.Weight
+		}
+		if a.Port > 0 {
+			req["port"] = a.Port
+		}
+		if err := client.do(ctx, "add", req, &resp); err != nil {
+			return nil, err
+		}
+		var result R
+		if record, ok := any(&result).(**DNSRecord); ok {
+			*record = &DNSRecord{IDs: resp.IDs}
+		}
+		return &result, nil
+
+	case *DNSDeleteAction:
+		req := map[string]interface{}{
+			"name": a.Name,
+		}
+		if len(a.IDs) > 0 {
+			req["ids"] = a.IDs
+		}
+		var resp struct {
+			Deleted bool `json:"deleted"`
+		}
+		if err := client.do(ctx, "delete", req, &resp); err != nil {
+			return nil, err
+		}
+		var result R
+		return &result, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported action type: %T", action)
+	}
 }

--- a/dns/aether.go
+++ b/dns/aether.go
@@ -268,28 +268,38 @@ func WithRedis(redis *redis.Client) optionHandler {
 	}
 }
 
+var defaultCatalystHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
 // WithCatalyst uses the Catalyst HTTP API for DNS operations.
 // apiURL is the base URL of the catalyst server (e.g., "https://catalyst.agentuity.cloud")
-// token is the aether API token (ak_ prefix) for authentication
+// token is the aether API token (ak_ prefix) for authentication.
+//
+// Note: Certificate actions (DNSCertAction) are not supported via Catalyst.
+// Use Redis transport (WithRedis) for certificate operations.
 func WithCatalyst(apiURL, token string) optionHandler {
 	return func(o *option) {
 		o.catalystClient = &catalystClient{
 			baseURL: strings.TrimSuffix(apiURL, "/"),
 			token:   token,
-			client: &http.Client{
-				Timeout: 30 * time.Second,
-			},
+			client:  defaultCatalystHTTPClient,
 		}
 	}
 }
 
 // WithCatalystClient uses a custom HTTP client with the Catalyst API.
+// If httpClient is nil, uses the default Catalyst HTTP client (10s timeout).
 func WithCatalystClient(apiURL, token string, httpClient *http.Client) optionHandler {
 	return func(o *option) {
+		client := httpClient
+		if client == nil {
+			client = defaultCatalystHTTPClient
+		}
 		o.catalystClient = &catalystClient{
 			baseURL: strings.TrimSuffix(apiURL, "/"),
 			token:   token,
-			client:  httpClient,
+			client:  client,
 		}
 	}
 }
@@ -509,8 +519,8 @@ func sendViaCatalyst[R any, T TypedDNSAction[R]](ctx context.Context, client *ca
 			return nil, err
 		}
 		var result R
-		if record, ok := any(&result).(**DNSRecord); ok {
-			*record = &DNSRecord{IDs: resp.IDs}
+		if record, ok := any(&result).(*DNSRecord); ok {
+			record.IDs = resp.IDs
 		}
 		return &result, nil
 
@@ -529,6 +539,9 @@ func sendViaCatalyst[R any, T TypedDNSAction[R]](ctx context.Context, client *ca
 		}
 		var result R
 		return &result, nil
+
+	case *DNSCertAction:
+		return nil, errors.New("certificate actions are not supported via Catalyst HTTP API; use Redis transport instead")
 
 	default:
 		return nil, fmt.Errorf("unsupported action type: %T", action)

--- a/dns/aether_test.go
+++ b/dns/aether_test.go
@@ -3,11 +3,14 @@ package dns
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testTransport struct {
@@ -102,4 +105,213 @@ func TestDNSCertAction(t *testing.T) {
 	a, err := ActionFromChannel("aether:response:cert:123")
 	assert.NoError(t, err)
 	assert.Equal(t, "cert", a)
+}
+
+func TestWithCatalyst_AddRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/aether/dns/add", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Contains(t, r.Header.Get("User-Agent"), "Agentuity")
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "test.example.com", req["name"])
+		assert.Equal(t, "A", req["type"])
+		assert.Equal(t, "10.0.0.1", req["value"])
+		assert.Equal(t, float64(60), req["ttl"])
+		assert.Equal(t, float64(300), req["expires"])
+
+		resp := map[string]interface{}{
+			"ids": []string{"record-123"},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1").
+		WithTTL(time.Minute).
+		WithExpires(5 * time.Minute)
+
+	result, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"record-123"}, result.IDs)
+}
+
+func TestWithCatalyst_AddRecordWithAllFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "srv.example.com", req["name"])
+		assert.Equal(t, "SRV", req["type"])
+		assert.Equal(t, "target.example.com", req["value"])
+		assert.Equal(t, float64(10), req["priority"])
+		assert.Equal(t, float64(20), req["weight"])
+		assert.Equal(t, float64(8080), req["port"])
+
+		resp := map[string]interface{}{
+			"ids": []string{"srv-456"},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	action := NewAddAction("srv.example.com", RecordTypeSRV, "target.example.com").
+		WithPriority(10).
+		WithWeight(20).
+		WithPort(8080)
+
+	result, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"srv-456"}, result.IDs)
+}
+
+func TestWithCatalyst_DeleteRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/aether/dns/delete", r.URL.Path)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "test.example.com", req["name"])
+		assert.Equal(t, []interface{}{"record-123"}, req["ids"])
+
+		resp := map[string]interface{}{
+			"deleted": true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	action := DeleteDNSAction("test.example.com", "record-123")
+
+	result, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.NoError(t, err)
+	_ = result
+}
+
+func TestWithCatalyst_DeleteRecordAllIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "test.example.com", req["name"])
+		_, hasIDs := req["ids"]
+		assert.False(t, hasIDs)
+
+		resp := map[string]interface{}{
+			"deleted": true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	action := DeleteDNSAction("test.example.com")
+
+	_, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.NoError(t, err)
+}
+
+func TestWithCatalyst_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		resp := map[string]interface{}{
+			"error": "missing dns:write scope",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1")
+
+	_, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing dns:write scope")
+}
+
+func TestWithCatalyst_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1")
+
+	_, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestWithCatalyst_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := SendDNSAction(ctx, action, WithCatalyst(server.URL, "test-token"))
+	require.Error(t, err)
+}
+
+func TestWithCatalystClient_CustomClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("User-Agent"), "Agentuity")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"ids": []string{"123"}})
+	}))
+	defer server.Close()
+
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1")
+
+	result, err := SendDNSAction(context.Background(), action, WithCatalystClient(server.URL, "test-token", customClient))
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestDefaultCatalystHTTPClient_Timeout(t *testing.T) {
+	assert.Equal(t, 10*time.Second, defaultCatalystHTTPClient.Timeout)
+}
+
+func TestWithCatalyst_CertActionNotSupported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called for cert action")
+	}))
+	defer server.Close()
+
+	action := CertRequestDNSAction("test.example.com")
+
+	_, err := SendDNSAction(context.Background(), action, WithCatalyst(server.URL, "test-token"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate actions are not supported")
+	assert.Contains(t, err.Error(), "Redis transport")
+}
+
+func TestWithCatalystClient_NilClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"ids": []string{"123"}})
+	}))
+	defer server.Close()
+
+	action := NewAddAction("test.example.com", RecordTypeA, "10.0.0.1")
+
+	result, err := SendDNSAction(context.Background(), action, WithCatalystClient(server.URL, "test-token", nil))
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, []string{"123"}, result.IDs)
 }


### PR DESCRIPTION
## Summary

Add ability to use Catalyst HTTP API for DNS operations instead of direct Redis pub/sub. This allows clients without Redis access to manage DNS records through the Catalyst API.

## Changes

- Add `WithCatalyst()` and `WithCatalystClient()` options for HTTP transport
- Export `OptionHandler` type for external use  
- Add `sendViaCatalyst()` for HTTP-based DNS add/delete operations
- Include User-Agent header in API requests using `api.UserAgent()`

## Usage

```go
// Via Redis (existing)
dns.SendDNSAction(ctx, action, dns.WithRedis(redisClient))

// Via Catalyst HTTP API (new)
dns.SendDNSAction(ctx, action, dns.WithCatalyst("https://catalyst-usc.agentuity.cloud", "ak_<token>"))
```

This enables gluon and other tools to use the DNS API without requiring direct Redis connectivity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalyst HTTP integration for DNS add/delete operations via a token-authenticated API endpoint
  * Public options to configure Catalyst integration and supply a custom HTTP client
  * Requests include JSON payloads, required headers, and sensible timeouts

* **Tests**
  * New integration-style tests validating request/response behavior, headers, timeouts, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->