### PR TITLE
fix: change synack.sending log from Info to Trace level

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4900,7 +4900,7 @@ func (g *GravityClient) WritePacket(payload []byte) error {
 			copy(dstIP, payload[24:40])
 			srcPort := binary.BigEndian.Uint16(payload[40:42])
 			dstPort := binary.BigEndian.Uint16(payload[42:44])
-			g.logger.Info("gravity.synack.sending src=%s:%d dst=%s:%d", srcIP, srcPort, dstIP, dstPort)
+			g.logger.Trace("gravity.synack.sending src=%s:%d dst=%s:%d", srcIP, srcPort, dstIP, dstPort)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Changed `gravity.synack.sending` log from Info to Trace level
- This log fires on every SYN+ACK packet and was too verbose for Info level
- Reduces log noise in production environments

## Test plan
- Verified hadron builds successfully with the change
- Tested with resume flow, confirmed logs are no longer at Info level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for network packet detection events to reduce log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->