### PR TITLE
fix: prefer IPv4 for GCE memberlist peer discovery

### DIFF
--- a/gravity/discovery/gce.go
+++ b/gravity/discovery/gce.go
@@ -111,13 +111,12 @@ func (g *GCEDiscoverer) Discover(ctx context.Context) ([]string, error) {
 		if !g.hasTag(inst) {
 			continue
 		}
-		// Extract the internal IP, preferring IPv6 (memberlist binds to IPv6
-		// when available, so peers must be reachable on their IPv6 address).
+		// Extract the internal IPv4 address. The IPv6 address on GCE
+		// instances is an overlay address (fd20:…) that is NOT routable
+		// between machines, causing memberlist peers to be unreachable.
+		// IPv4 private addresses (10.x.x.x) are always routable within
+		// the VPC.
 		for _, iface := range inst.NetworkInterfaces {
-			if iface.IPv6Address != "" {
-				peers = append(peers, iface.IPv6Address)
-				break
-			}
 			if iface.NetworkIP != "" {
 				peers = append(peers, iface.NetworkIP)
 				break


### PR DESCRIPTION
## Summary
- GCE peer discoverer was preferring IPv6 overlay addresses (`fd20:…`) that are **not routable** between machines
- This caused all memberlist join attempts to fail with `network is unreachable`, fragmenting the cluster into solo nodes
- Switch to preferring IPv4 `NetworkIP` (`10.x.x.x`) which is always routable within the VPC

## Context
All three production ion instances were running as isolated memberlist solo nodes because the overlay IPv6 addresses used for peer discovery are unreachable between machines. This broke gossip propagation entirely, preventing endpoint table entries (including devmode dynamic hostnames) from being shared across ions.

The ion-side companion fix (using IPv4 for memberlist bind address) is in [agentuity/ion@task/debug-sandbox](https://github.com/agentuity/ion/tree/task/debug-sandbox).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed peer IP address discovery for Google Compute Engine instances to use the correct network IP address selection logic, ensuring more reliable peer detection for tagged running instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->