### PR TITLE
fix: preserve session config on multi-tunnel reuse + deployment subnet VIPs

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -2583,11 +2583,27 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	g.authorizationToken = response.MachineToken
 	g.connectionIDs = append(g.connectionIDs, response.MachineId)
 
-	g.otlpURL = response.OtlpUrl
-	g.otlpToken = response.OtlpKey
-	g.apiURL = response.ApiUrl
-	g.hostEnvironment = response.Environment
-	g.hostMapping = response.HostMapping
+	// Only update config values when non-empty. Multi-tunnel reuse sessions
+	// return minimal responses without these fields — don't overwrite the
+	// good config from the primary session.
+	g.logger.Info("[session-config] response: apiUrl=%q otlpUrl=%q env=%d hostMappings=%d machineId=%s server=%s",
+		response.ApiUrl, response.OtlpUrl, len(response.Environment), len(response.HostMapping), response.MachineId, response.GravityServer)
+	if response.OtlpUrl != "" {
+		g.otlpURL = response.OtlpUrl
+	}
+	if response.OtlpKey != "" {
+		g.otlpToken = response.OtlpKey
+	}
+	if response.ApiUrl != "" {
+		g.apiURL = response.ApiUrl
+	}
+	if len(response.Environment) > 0 {
+		g.hostEnvironment = response.Environment
+	}
+	if len(response.HostMapping) > 0 {
+		g.hostMapping = response.HostMapping
+	}
+	g.logger.Info("[session-config] effective: apiUrl=%q otlpUrl=%q hostMappings=%d", g.apiURL, g.otlpURL, len(g.hostMapping))
 
 	if len(response.SshPublicKey) > 0 {
 		g.logger.Trace("received SSH public key from Gravity (%d bytes)", len(response.SshPublicKey))

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -287,6 +287,7 @@ type GravityClient struct {
 	connected            bool
 	reconnecting         bool          // Tracks if reconnection is in progress
 	endpointReconnecting []atomic.Bool // Per-endpoint reconnect guard (multi-endpoint only)
+	endpointFailCount    []atomic.Int32
 	connectionIDs        []string      // Stores connection IDs from server responses
 	connectionIDChan     chan string   // Channel to signal when connection ID is received
 	helloAckedStreams    sync.Map      // streamIndex (int) → true: tracks which streams received SessionHelloResponse
@@ -380,6 +381,8 @@ type StreamInfo struct {
 	lastUsed  time.Time  // Last time this stream was used
 	sendMu    sync.Mutex // Serializes Send calls on this stream
 }
+
+const endpointDiscoveryRefreshFailureThreshold int32 = 10
 
 // StreamManager manages multiple gRPC streams for multiplexing with advanced load balancing
 type StreamManager struct {
@@ -794,7 +797,7 @@ func (g *GravityClient) startMultiEndpoint() error {
 
 			// If hostname is already an IP address, skip DNS lookup
 			if ip := net.ParseIP(hostname); ip != nil {
-				ep := &GravityEndpoint{URL: endpointURL}
+				ep := &GravityEndpoint{URL: endpointURL, TLSServerName: g.preferredTLSServerName(endpointURL)}
 				ep.healthy.Store(false)
 				g.endpoints = append(g.endpoints, ep)
 				continue
@@ -829,12 +832,12 @@ func (g *GravityClient) startMultiEndpoint() error {
 				}
 			} else {
 				// DNS returned no IPs, fall back to original URL
-				ep := &GravityEndpoint{URL: endpointURL}
+				ep := &GravityEndpoint{URL: endpointURL, TLSServerName: g.preferredTLSServerName(endpointURL)}
 				ep.healthy.Store(false)
 				g.endpoints = append(g.endpoints, ep)
 			}
 		} else {
-			ep := &GravityEndpoint{URL: endpointURL}
+			ep := &GravityEndpoint{URL: endpointURL, TLSServerName: g.preferredTLSServerName(endpointURL)}
 			ep.healthy.Store(false)
 			g.endpoints = append(g.endpoints, ep)
 		}
@@ -899,6 +902,7 @@ func (g *GravityClient) startMultiEndpoint() error {
 	g.circuitBreakers = make([]*CircuitBreaker, connectionCount)
 	g.connectionURLs = make([]string, connectionCount)
 	g.endpointReconnecting = make([]atomic.Bool, connectionCount)
+	g.endpointFailCount = make([]atomic.Int32, connectionCount)
 	g.endpointStreamIndices = make(map[string][]int)
 
 	// Initialize connection health tracking
@@ -1638,7 +1642,7 @@ func (g *GravityClient) cycleEndpoint(oldURL, newURL string) {
 		return
 	}
 
-	newEp := &GravityEndpoint{URL: newURL}
+	newEp := &GravityEndpoint{URL: newURL, TLSServerName: g.preferredTLSServerName(newURL)}
 	newEp.healthy.Store(false)
 	g.endpoints[oldIdx] = newEp
 	g.endpointsMu.Unlock()
@@ -1681,7 +1685,7 @@ func (g *GravityClient) addEndpoint(newURL string) {
 		}
 	}
 
-	newEp := &GravityEndpoint{URL: newURL}
+	newEp := &GravityEndpoint{URL: newURL, TLSServerName: g.preferredTLSServerName(newURL)}
 	newEp.healthy.Store(false) // will become healthy after reconnection
 	g.endpoints[slotIdx] = newEp
 	g.endpointsMu.Unlock()
@@ -1705,6 +1709,9 @@ func (g *GravityClient) addEndpoint(newURL string) {
 	}
 	for len(g.endpointReconnecting) <= slotIdx {
 		g.endpointReconnecting = append(g.endpointReconnecting, atomic.Bool{})
+	}
+	for len(g.endpointFailCount) <= slotIdx {
+		g.endpointFailCount = append(g.endpointFailCount, atomic.Int32{})
 	}
 	g.mu.Unlock()
 
@@ -3644,6 +3651,134 @@ func (g *GravityClient) hasHealthyEndpoint() bool {
 	return false
 }
 
+func (g *GravityClient) preferredTLSServerName(endpointURL string) string {
+	if strings.TrimSpace(endpointURL) == "" {
+		return ""
+	}
+	hostPort, err := g.parseGRPCURL(endpointURL)
+	if err != nil {
+		return g.defaultServerName
+	}
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return g.defaultServerName
+	}
+	if net.ParseIP(host) != nil {
+		return g.defaultServerName
+	}
+	return host
+}
+
+func (g *GravityClient) resetEndpointFailureCount(endpointIndex int) {
+	g.mu.RLock()
+	if endpointIndex >= 0 && endpointIndex < len(g.endpointFailCount) {
+		g.endpointFailCount[endpointIndex].Store(0)
+	}
+	g.mu.RUnlock()
+}
+
+func (g *GravityClient) incrementEndpointFailureCount(endpointIndex int) int32 {
+	g.mu.RLock()
+	if endpointIndex < 0 || endpointIndex >= len(g.endpointFailCount) {
+		g.mu.RUnlock()
+		return 0
+	}
+	count := g.endpointFailCount[endpointIndex].Add(1)
+	g.mu.RUnlock()
+	return count
+}
+
+func (g *GravityClient) handleEndpointReconnectFailure(endpointIndex int, currentURL string) string {
+	failures := g.incrementEndpointFailureCount(endpointIndex)
+	if failures == 0 {
+		return currentURL
+	}
+
+	if failures%endpointDiscoveryRefreshFailureThreshold != 0 {
+		return currentURL
+	}
+
+	g.logger.Info("endpoint %d reached %d consecutive reconnection failures; refreshing service discovery",
+		endpointIndex, failures)
+
+	refreshedURL := g.refreshFailingEndpointFromDiscovery(endpointIndex, currentURL)
+	if refreshedURL == "" || refreshedURL == currentURL {
+		g.logger.Info("endpoint %d discovery refresh found no replacement after %d failures", endpointIndex, failures)
+		return currentURL
+	}
+
+	g.logger.Info("endpoint %d discovery refresh replaced %s -> %s after %d failures",
+		endpointIndex, currentURL, refreshedURL, failures)
+	g.resetEndpointFailureCount(endpointIndex)
+	return refreshedURL
+}
+
+func (g *GravityClient) refreshFailingEndpointFromDiscovery(endpointIndex int, currentURL string) string {
+	if g.discoveryResolveFunc == nil {
+		return ""
+	}
+
+	candidates := g.discoveryResolveFunc()
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	unique := make([]string, 0, len(candidates))
+	seen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		c = strings.TrimSpace(c)
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		unique = append(unique, c)
+	}
+	if len(unique) == 0 {
+		return ""
+	}
+
+	inUse := make(map[string]bool)
+	g.endpointsMu.RLock()
+	for i, ep := range g.endpoints {
+		if i == endpointIndex || ep == nil || strings.TrimSpace(ep.URL) == "" {
+			continue
+		}
+		inUse[ep.URL] = true
+	}
+	g.endpointsMu.RUnlock()
+
+	var replacement string
+	for _, c := range unique {
+		if c == currentURL || inUse[c] {
+			continue
+		}
+		replacement = c
+		break
+	}
+	if replacement == "" {
+		return ""
+	}
+
+	tlsServerName := g.preferredTLSServerName(replacement)
+
+	g.endpointsMu.Lock()
+	if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
+		g.endpoints[endpointIndex].URL = replacement
+		if tlsServerName != "" {
+			g.endpoints[endpointIndex].TLSServerName = tlsServerName
+		}
+	}
+	g.endpointsMu.Unlock()
+
+	g.mu.Lock()
+	if endpointIndex >= 0 && endpointIndex < len(g.connectionURLs) {
+		g.connectionURLs[endpointIndex] = replacement
+	}
+	g.mu.Unlock()
+
+	return replacement
+}
+
 func (g *GravityClient) reconnectEndpoint(endpointIndex int, reason string) {
 	defer g.endpointReconnecting[endpointIndex].Store(false)
 
@@ -3709,7 +3844,9 @@ func (g *GravityClient) reconnectEndpoint(endpointIndex int, reason string) {
 		g.logger.Info("endpoint %d reconnection attempt %d", endpointIndex, attempt)
 		if err := g.reconnectSingleEndpoint(endpointIndex, endpointURL); err != nil {
 			g.logger.Warn("endpoint %d reconnection attempt %d failed: %v", endpointIndex, attempt, err)
+			endpointURL = g.handleEndpointReconnectFailure(endpointIndex, endpointURL)
 		} else {
+			g.resetEndpointFailureCount(endpointIndex)
 			g.logger.Info("endpoint %d (%s) reconnected successfully after %d attempt(s)", endpointIndex, endpointURL, attempt)
 			return
 		}

--- a/gravity/proto/gravity_session.pb.go
+++ b/gravity/proto/gravity_session.pb.go
@@ -1941,7 +1941,8 @@ type ExistingDeployment struct {
 	Paused         bool                   `protobuf:"varint,9,opt,name=paused,proto3" json:"paused,omitempty"`
 	PausedDuration *durationpb.Duration   `protobuf:"bytes,10,opt,name=pausedDuration,proto3" json:"pausedDuration,omitempty"`
 	OnDemand       bool                   `protobuf:"varint,11,opt,name=on_demand,json=onDemand,proto3" json:"on_demand,omitempty"`
-	Cert           string                 `protobuf:"bytes,12,opt,name=cert,proto3" json:"cert,omitempty"` // PEM certificate that was issued (just cert, ca + key not required)
+	Cert           string                 `protobuf:"bytes,12,opt,name=cert,proto3" json:"cert,omitempty"`                   // PEM certificate that was issued (just cert, ca + key not required)
+	PausedTimeout  *durationpb.Duration   `protobuf:"bytes,13,opt,name=pausedTimeout,proto3" json:"pausedTimeout,omitempty"` // Per-sandbox paused timeout (0 = infinite)
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2051,6 +2052,13 @@ func (x *ExistingDeployment) GetCert() string {
 		return x.Cert
 	}
 	return ""
+}
+
+func (x *ExistingDeployment) GetPausedTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.PausedTimeout
+	}
+	return nil
 }
 
 type ResourceRequirements struct {
@@ -3550,7 +3558,7 @@ const file_gravity_session_proto_rawDesc = "" +
 	" \x01(\tR\x06region\x12#\n" +
 	"\rinstance_type\x18\v \x01(\tR\finstanceType\x12#\n" +
 	"\rinstance_tags\x18\f \x03(\tR\finstanceTags\x12+\n" +
-	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\"\xc9\x03\n" +
+	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\"\x8a\x04\n" +
 	"\x12ExistingDeployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +
 	"\astarted\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\astarted\x12!\n" +
@@ -3563,7 +3571,8 @@ const file_gravity_session_proto_rawDesc = "" +
 	"\x0epausedDuration\x18\n" +
 	" \x01(\v2\x19.google.protobuf.DurationR\x0epausedDuration\x12\x1b\n" +
 	"\ton_demand\x18\v \x01(\bR\bonDemand\x12\x12\n" +
-	"\x04cert\x18\f \x01(\tR\x04cert\"\xe0\x01\n" +
+	"\x04cert\x18\f \x01(\tR\x04cert\x12?\n" +
+	"\rpausedTimeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\rpausedTimeout\"\xe0\x01\n" +
 	"\x14ResourceRequirements\x12!\n" +
 	"\fmemory_limit\x18\x01 \x01(\x03R\vmemoryLimit\x12\x1b\n" +
 	"\tcpu_limit\x18\x02 \x01(\x03R\bcpuLimit\x12%\n" +
@@ -3805,28 +3814,29 @@ var file_gravity_session_proto_depIdxs = []int32{
 	25, // 33: gravity.ExistingDeployment.resources:type_name -> gravity.ResourceRequirements
 	26, // 34: gravity.ExistingDeployment.deployment_cert:type_name -> gravity.DeploymentCert
 	48, // 35: gravity.ExistingDeployment.pausedDuration:type_name -> google.protobuf.Duration
-	28, // 36: gravity.CodeMetadata.secret_rules:type_name -> gravity.SecretRule
-	0,  // 37: gravity.SecretRule.scheme:type_name -> gravity.SecretScheme
-	27, // 38: gravity.DeploymentMetadataResponse.code_metadata:type_name -> gravity.CodeMetadata
-	26, // 39: gravity.DeploymentMetadataResponse.deployment_cert:type_name -> gravity.DeploymentCert
-	36, // 40: gravity.EvacuateRequest.sandboxes:type_name -> gravity.SandboxEvacInfo
-	38, // 41: gravity.EvacuationPlan.sandboxes:type_name -> gravity.EvacuateSandboxPlan
-	1,  // 42: gravity.CheckpointURLRequest.operation:type_name -> gravity.CheckpointURLOperation
-	4,  // 43: gravity.GravitySessionService.EstablishSession:input_type -> gravity.SessionMessage
-	8,  // 44: gravity.GravitySessionService.StreamSessionPackets:input_type -> gravity.TunnelPacket
-	30, // 45: gravity.GravitySessionService.GetDeploymentMetadata:input_type -> gravity.DeploymentMetadataRequest
-	34, // 46: gravity.GravitySessionService.GetSandboxMetadata:input_type -> gravity.SandboxMetadataRequest
-	2,  // 47: gravity.GravitySessionService.Identify:input_type -> gravity.IdentifyRequest
-	4,  // 48: gravity.GravitySessionService.EstablishSession:output_type -> gravity.SessionMessage
-	8,  // 49: gravity.GravitySessionService.StreamSessionPackets:output_type -> gravity.TunnelPacket
-	31, // 50: gravity.GravitySessionService.GetDeploymentMetadata:output_type -> gravity.DeploymentMetadataResponse
-	35, // 51: gravity.GravitySessionService.GetSandboxMetadata:output_type -> gravity.SandboxMetadataResponse
-	3,  // 52: gravity.GravitySessionService.Identify:output_type -> gravity.IdentifyResponse
-	48, // [48:53] is the sub-list for method output_type
-	43, // [43:48] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	48, // 36: gravity.ExistingDeployment.pausedTimeout:type_name -> google.protobuf.Duration
+	28, // 37: gravity.CodeMetadata.secret_rules:type_name -> gravity.SecretRule
+	0,  // 38: gravity.SecretRule.scheme:type_name -> gravity.SecretScheme
+	27, // 39: gravity.DeploymentMetadataResponse.code_metadata:type_name -> gravity.CodeMetadata
+	26, // 40: gravity.DeploymentMetadataResponse.deployment_cert:type_name -> gravity.DeploymentCert
+	36, // 41: gravity.EvacuateRequest.sandboxes:type_name -> gravity.SandboxEvacInfo
+	38, // 42: gravity.EvacuationPlan.sandboxes:type_name -> gravity.EvacuateSandboxPlan
+	1,  // 43: gravity.CheckpointURLRequest.operation:type_name -> gravity.CheckpointURLOperation
+	4,  // 44: gravity.GravitySessionService.EstablishSession:input_type -> gravity.SessionMessage
+	8,  // 45: gravity.GravitySessionService.StreamSessionPackets:input_type -> gravity.TunnelPacket
+	30, // 46: gravity.GravitySessionService.GetDeploymentMetadata:input_type -> gravity.DeploymentMetadataRequest
+	34, // 47: gravity.GravitySessionService.GetSandboxMetadata:input_type -> gravity.SandboxMetadataRequest
+	2,  // 48: gravity.GravitySessionService.Identify:input_type -> gravity.IdentifyRequest
+	4,  // 49: gravity.GravitySessionService.EstablishSession:output_type -> gravity.SessionMessage
+	8,  // 50: gravity.GravitySessionService.StreamSessionPackets:output_type -> gravity.TunnelPacket
+	31, // 51: gravity.GravitySessionService.GetDeploymentMetadata:output_type -> gravity.DeploymentMetadataResponse
+	35, // 52: gravity.GravitySessionService.GetSandboxMetadata:output_type -> gravity.SandboxMetadataResponse
+	3,  // 53: gravity.GravitySessionService.Identify:output_type -> gravity.IdentifyResponse
+	49, // [49:54] is the sub-list for method output_type
+	44, // [44:49] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_gravity_session_proto_init() }

--- a/gravity/proto/gravity_session.proto
+++ b/gravity/proto/gravity_session.proto
@@ -252,6 +252,7 @@ message ExistingDeployment {
   google.protobuf.Duration pausedDuration = 10;
   bool on_demand = 11;
   string cert = 12; // PEM certificate that was issued (just cert, ca + key not required)
+  google.protobuf.Duration pausedTimeout = 13; // Per-sandbox paused timeout (0 = infinite)
 }
 
 message ResourceRequirements {

--- a/gravity/provider/provider.go
+++ b/gravity/provider/provider.go
@@ -69,11 +69,12 @@ type Configuration struct {
 type DeprovisionReason string
 
 const (
-	DeprovisionReasonIdleTimeout DeprovisionReason = "idle_timeout"
-	DeprovisionReasonError       DeprovisionReason = "error"
-	DeprovisionReasonExited      DeprovisionReason = "exit"
-	DeprovisionReasonShutdown    DeprovisionReason = "shutdown"
-	DeprovisionReasonUnprovision DeprovisionReason = "unprovision"
+	DeprovisionReasonIdleTimeout  DeprovisionReason = "idle_timeout"
+	DeprovisionReasonPausedTimeout DeprovisionReason = "paused_timeout"
+	DeprovisionReasonError        DeprovisionReason = "error"
+	DeprovisionReasonExited       DeprovisionReason = "exit"
+	DeprovisionReasonShutdown     DeprovisionReason = "shutdown"
+	DeprovisionReasonUnprovision  DeprovisionReason = "unprovision"
 )
 
 // Provider interface defines the minimal set of methods required by the gravity client

--- a/gravity/reconnect_discovery_refresh_test.go
+++ b/gravity/reconnect_discovery_refresh_test.go
@@ -1,0 +1,82 @@
+package gravity
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agentuity/go-common/logger"
+)
+
+func newReconnectRefreshTestClient(endpoints []*GravityEndpoint, urls []string, discover func() []string) *GravityClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := &GravityClient{
+		ctx:                  ctx,
+		cancel:               cancel,
+		logger:               logger.NewTestLogger(),
+		defaultServerName:    "gravity-usw.agentuity.cloud",
+		endpoints:            endpoints,
+		connectionURLs:       urls,
+		endpointFailCount:    make([]atomic.Int32, len(endpoints)),
+		discoveryResolveFunc: discover,
+	}
+	return g
+}
+
+func TestGravityClient_ReResolvesAfterFailures(t *testing.T) {
+	endpoints := []*GravityEndpoint{{URL: "grpc://10.0.0.1:443"}}
+	urls := []string{"grpc://10.0.0.1:443"}
+	g := newReconnectRefreshTestClient(endpoints, urls, func() []string {
+		return []string{"grpc://10.0.0.1:443", "grpc://10.0.0.99:443"}
+	})
+	t.Cleanup(g.cancel)
+
+	current := "grpc://10.0.0.1:443"
+	for i := int32(1); i < endpointDiscoveryRefreshFailureThreshold; i++ {
+		updated := g.handleEndpointReconnectFailure(0, current)
+		if updated != current {
+			t.Fatalf("unexpected URL change before threshold at attempt %d: %s", i, updated)
+		}
+	}
+
+	updated := g.handleEndpointReconnectFailure(0, current)
+	if updated != "grpc://10.0.0.99:443" {
+		t.Fatalf("expected URL to refresh at threshold, got %s", updated)
+	}
+	if g.endpoints[0].URL != "grpc://10.0.0.99:443" {
+		t.Fatalf("expected endpoint URL updated, got %s", g.endpoints[0].URL)
+	}
+	if g.connectionURLs[0] != "grpc://10.0.0.99:443" {
+		t.Fatalf("expected connection URL updated, got %s", g.connectionURLs[0])
+	}
+}
+
+func TestGravityClient_MixedEndpoints_OnlyReResolveFailing(t *testing.T) {
+	endpoints := []*GravityEndpoint{
+		{URL: "grpc://10.0.0.1:443"},
+		{URL: "grpc://10.0.0.2:443"},
+	}
+	urls := []string{"grpc://10.0.0.1:443", "grpc://10.0.0.2:443"}
+	g := newReconnectRefreshTestClient(endpoints, urls, func() []string {
+		return []string{"grpc://10.0.0.1:443", "grpc://10.0.0.2:443", "grpc://10.0.0.77:443"}
+	})
+	t.Cleanup(g.cancel)
+
+	current := "grpc://10.0.0.1:443"
+	for i := int32(0); i < endpointDiscoveryRefreshFailureThreshold; i++ {
+		current = g.handleEndpointReconnectFailure(0, current)
+	}
+
+	if g.endpoints[0].URL != "grpc://10.0.0.77:443" {
+		t.Fatalf("expected failing endpoint to refresh, got %s", g.endpoints[0].URL)
+	}
+	if g.endpoints[1].URL != "grpc://10.0.0.2:443" {
+		t.Fatalf("expected healthy endpoint unchanged, got %s", g.endpoints[1].URL)
+	}
+	if g.connectionURLs[1] != "grpc://10.0.0.2:443" {
+		t.Fatalf("expected healthy endpoint connection URL unchanged, got %s", g.connectionURLs[1])
+	}
+	if g.endpointFailCount[1].Load() != 0 {
+		t.Fatalf("expected non-failing endpoint failure count untouched, got %d", g.endpointFailCount[1].Load())
+	}
+}

--- a/network/subnet.go
+++ b/network/subnet.go
@@ -9,6 +9,10 @@ import (
 // This is separate from NetworkHadron (0x03) to avoid address collisions.
 const NetworkSandboxSubnet Network = 0x05
 
+// NetworkDeploymentSubnet is the network type for deployment subnets.
+// This is separate from NetworkSandboxSubnet (0x05) to avoid collisions.
+const NetworkDeploymentSubnet Network = 0x06
+
 // ComputeSandboxSubnet returns a deterministic /64 IPv6 subnet for a machine.
 // Both gravity and hadron must call this function with the same parameters
 // (region, machineID) to produce identical results.
@@ -67,6 +71,50 @@ func ComputeSandboxVIP(subnet netip.Prefix, sandboxID string) netip.Addr {
 	base[12] = byte((h >> 12) & 0xff)
 	base[13] = byte((h >> 4) & 0xff)
 	base[14] = byte((h >> 20) & 0xff)
+	base[15] = byte(h&0xff) | 1
+
+	addr, _ := netip.AddrFromSlice(base[:])
+	return addr
+}
+
+// ComputeDeploymentSubnet returns a deterministic /96 IPv6 subnet for a machine.
+// Both gravity and hadron must call this function with the same parameters
+// (region, machineID) to produce identical results.
+//
+// Address format: fd15:d710:RNMM:MMMM::/96
+//   - Byte 4: Region (5 bits, max 31) | Network (3 bits, max 7)
+//   - Bytes 5-7: Machine hash (24 bits, 16M buckets)
+func ComputeDeploymentSubnet(region Region, machineID string) netip.Prefix {
+	machineHash := hashTo32Bits(machineID)
+
+	b := make([]byte, 16)
+	b[0] = 0xfd
+	b[1] = 0x15
+	b[2] = 0xd7
+	b[3] = 0x10
+	b[4] = (byte(region) << 3) | (byte(NetworkDeploymentSubnet) & 0x07)
+	b[5] = byte((machineHash >> 16) & 0xff)
+	b[6] = byte((machineHash >> 8) & 0xff)
+	b[7] = byte(machineHash & 0xff)
+	// Bytes 8-15 are zero for the prefix
+
+	addr, _ := netip.AddrFromSlice(b)
+	return netip.PrefixFrom(addr, 96)
+}
+
+// ComputeDeploymentVIP returns a deterministic IPv6 address for a deployment
+// within its machine's subnet. The subnet must be a /96 prefix; the host
+// bits (bytes 12-15) are derived from the deploymentID hash.
+func ComputeDeploymentVIP(subnet netip.Prefix, deploymentID string) netip.Addr {
+	if subnet.Bits() != 96 {
+		panic(fmt.Sprintf("ComputeDeploymentVIP requires a /96 prefix, got /%d", subnet.Bits()))
+	}
+	h := hashTo32Bits(deploymentID)
+	base := subnet.Addr().As16()
+
+	base[12] = byte((h >> 24) & 0xff)
+	base[13] = byte((h >> 16) & 0xff)
+	base[14] = byte((h >> 8) & 0xff)
 	base[15] = byte(h&0xff) | 1
 
 	addr, _ := netip.AddrFromSlice(base[:])

--- a/network/subnet_test.go
+++ b/network/subnet_test.go
@@ -362,3 +362,112 @@ func TestComputeSandboxVIP_CollisionResistance(t *testing.T) {
 		t.Errorf("VIP collision rate should be < 0.1%% at 10000 sandboxes: got %.6f%%", collisionRate*100)
 	}
 }
+
+func TestComputeDeploymentSubnet_Consistency(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+
+	subnet1 := ComputeDeploymentSubnet(region, machineID)
+	subnet2 := ComputeDeploymentSubnet(region, machineID)
+
+	if subnet1 != subnet2 {
+		t.Errorf("ComputeDeploymentSubnet should produce consistent results:\n  got1: %s\n  got2: %s", subnet1, subnet2)
+	}
+}
+
+func TestComputeDeploymentSubnet_DifferentMachines(t *testing.T) {
+	region := RegionUSWest1
+
+	subnet1 := ComputeDeploymentSubnet(region, "machine_001")
+	subnet2 := ComputeDeploymentSubnet(region, "machine_002")
+
+	if subnet1 == subnet2 {
+		t.Errorf("ComputeDeploymentSubnet should produce different subnets for different machines:\n  got: %s", subnet1)
+	}
+}
+
+func TestComputeDeploymentSubnet_ValidPrefix(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+
+	subnet := ComputeDeploymentSubnet(region, machineID)
+
+	if !subnet.IsValid() {
+		t.Errorf("ComputeDeploymentSubnet should produce valid prefix: got %s", subnet)
+	}
+
+	if subnet.Bits() != 96 {
+		t.Errorf("ComputeDeploymentSubnet should produce /96 prefix: got /%d", subnet.Bits())
+	}
+}
+
+func TestComputeDeploymentSubnet_NetworkType(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+
+	subnet := ComputeDeploymentSubnet(region, machineID)
+	addr := subnet.Addr().As16()
+
+	networkType := addr[4] & 0x07
+	if networkType != byte(NetworkDeploymentSubnet) {
+		t.Errorf("Subnet should have NetworkDeploymentSubnet (0x06) in byte 4 low 3 bits: got 0x%02x", networkType)
+	}
+}
+
+func TestComputeDeploymentVIP_WithinSubnet(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+	deploymentID := "deployment_001"
+
+	subnet := ComputeDeploymentSubnet(region, machineID)
+	vip := ComputeDeploymentVIP(subnet, deploymentID)
+
+	if !subnet.Contains(vip) {
+		t.Errorf("ComputeDeploymentVIP should produce address within subnet:\n  subnet: %s\n  vip: %s", subnet, vip)
+	}
+}
+
+func TestComputeDeploymentVIP_PanicsOnNon96Prefix(t *testing.T) {
+	b := make([]byte, 16)
+	b[0] = 0xfd
+	b[1] = 0x15
+	addr, _ := netip.AddrFromSlice(b)
+	prefix80 := netip.PrefixFrom(addr, 80)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("ComputeDeploymentVIP should panic on non-/96 prefix")
+		}
+	}()
+
+	ComputeDeploymentVIP(prefix80, "deployment_001")
+}
+
+func TestComputeDeploymentVIP_DifferentDeployments(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+
+	subnet := ComputeDeploymentSubnet(region, machineID)
+
+	vip1 := ComputeDeploymentVIP(subnet, "deployment_001")
+	vip2 := ComputeDeploymentVIP(subnet, "deployment_002")
+
+	if vip1 == vip2 {
+		t.Errorf("ComputeDeploymentVIP should produce different addresses for different deployments:\n  got: %s", vip1)
+	}
+}
+
+func TestComputeDeploymentVIP_Consistency(t *testing.T) {
+	region := RegionUSWest1
+	machineID := "machine_xyz789"
+	deploymentID := "deployment_001"
+
+	subnet := ComputeDeploymentSubnet(region, machineID)
+
+	vip1 := ComputeDeploymentVIP(subnet, deploymentID)
+	vip2 := ComputeDeploymentVIP(subnet, deploymentID)
+
+	if vip1 != vip2 {
+		t.Errorf("ComputeDeploymentVIP should produce consistent results:\n  got1: %s\n  got2: %s", vip1, vip2)
+	}
+}


### PR DESCRIPTION
## Summary

- **Preserve session config values on multi-tunnel reuse**: Multi-tunnel reuse sessions return minimal responses without ApiUrl, OtlpUrl, HostMapping, etc. Previously these empty values overwrote the good config from the primary session, causing the hadron to lose its API URL and fail to download deployment code. Now only non-empty values update the stored config.

- **Add deterministic per-machine deployment subnet and VIP**: New `ComputeDeploymentSubnet` and `ComputeDeploymentVIP` functions that compute deterministic /96 subnets per machine for deployment VIPs, mirroring the sandbox subnet pattern.

- **Refresh failing gravity endpoints from discovery**: Re-resolves gravity endpoints after 10 consecutive failures to handle DNS changes.

- **Add per-sandbox paused timeout to ExistingDeployment proto**: Extends the proto with paused timeout field for sandbox lifecycle management.

## Testing
- All changes tested end-to-end in local dev with 3 ions + 1 hadron
- Deploy flow verified: `agentuity deploy` succeeds with all fixes
- Warm routing verified: all hostname types (d-hash, p-hash, vanity) return 200 on all 3 ions
- VXLAN cross-ion routing verified for deployment VIPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment pause timeout configuration capability
  * Introduced deployment-specific subnet and VIP support

* **Improvements**
  * Enhanced endpoint recovery with automatic URL refresh on repeated connection failures
  * Improved TLS configuration handling for IP-based endpoints
  * Refined session configuration to preserve existing settings during updates

* **Bug Fixes**
  * Added paused timeout deprovision reason for proper lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->