### PR TITLE
fix: preserve session config on multi-tunnel reuse

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -174,6 +174,9 @@ func (d *Dns) LookupMulti(ctx context.Context, hostname string) (bool, []net.IP,
 	// order). This is critical in environments where /etc/hosts has the
 	// correct mapping but external DNS returns a different address.
 	if ip := resolveFromHostsFile(hostname); ip != nil {
+		if !d.isLocal && (ip.IsPrivate() || ip.IsLoopback()) {
+			return false, nil, fmt.Errorf("hostname %s resolved to local/private address %s via /etc/hosts", hostname, ip)
+		}
 		return true, []net.IP{ip}, nil
 	}
 	hostname = formatFQDN(hostname)

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/agentuity/go-common/cache"
@@ -168,6 +169,13 @@ func (d *Dns) LookupMulti(ctx context.Context, hostname string) (bool, []net.IP,
 		}
 		return true, []net.IP{ip}, nil
 	}
+	// Check /etc/hosts before DNS-over-HTTPS. The system hosts file takes
+	// precedence over external resolvers (matching nsswitch.conf "files dns"
+	// order). This is critical in environments where /etc/hosts has the
+	// correct mapping but external DNS returns a different address.
+	if ip := resolveFromHostsFile(hostname); ip != nil {
+		return true, []net.IP{ip}, nil
+	}
 	hostname = formatFQDN(hostname)
 	var cacheKey string
 	if d.cache != nil {
@@ -277,4 +285,71 @@ func WithCache(cache cache.Cache) WithConfig {
 	return func(config *dnsConfig) {
 		config.Cache = cache
 	}
+}
+
+// hostsFileCache caches parsed /etc/hosts entries to avoid reading
+// the file on every DNS lookup. Refreshed every 30 seconds.
+var (
+	hostsFileMu       sync.RWMutex
+	hostsFileEntries  map[string]net.IP // lowercase hostname → IP
+	hostsFileLoadedAt time.Time
+	hostsFileTTL      = 30 * time.Second
+)
+
+// ResolveFromHostsFile looks up a hostname in /etc/hosts (cached).
+// Returns the first matching IP, or nil if not found.
+func ResolveFromHostsFile(hostname string) net.IP {
+	return resolveFromHostsFile(hostname)
+}
+
+func resolveFromHostsFile(hostname string) net.IP {
+	hostsFileMu.RLock()
+	if hostsFileEntries != nil && time.Since(hostsFileLoadedAt) < hostsFileTTL {
+		ip := hostsFileEntries[strings.ToLower(strings.TrimSuffix(hostname, "."))]
+		hostsFileMu.RUnlock()
+		return ip
+	}
+	hostsFileMu.RUnlock()
+
+	// Reload
+	hostsFileMu.Lock()
+	defer hostsFileMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if hostsFileEntries != nil && time.Since(hostsFileLoadedAt) < hostsFileTTL {
+		return hostsFileEntries[strings.ToLower(strings.TrimSuffix(hostname, "."))]
+	}
+
+	data, err := os.ReadFile("/etc/hosts")
+	if err != nil {
+		hostsFileEntries = make(map[string]net.IP)
+		hostsFileLoadedAt = time.Now()
+		return nil
+	}
+
+	entries := make(map[string]net.IP)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ip := net.ParseIP(fields[0])
+		if ip == nil {
+			continue
+		}
+		for _, name := range fields[1:] {
+			lower := strings.ToLower(name)
+			if _, exists := entries[lower]; !exists {
+				entries[lower] = ip
+			}
+		}
+	}
+	hostsFileEntries = entries
+	hostsFileLoadedAt = time.Now()
+
+	return entries[strings.ToLower(strings.TrimSuffix(hostname, "."))]
 }

--- a/gravity/gossip/types.go
+++ b/gravity/gossip/types.go
@@ -49,6 +49,7 @@ type EndpointMapping struct {
 	ProjectID   string   `json:"project_id"`
 	DNSNames    []string `json:"dns_names"`
 	Timestamp   int64    `json:"timestamp"`
+	SNIHostname string   `json:"sni_hostname,omitempty"` // d-hash for deployments, sandbox hostname for sandboxes
 }
 
 // EndpointTombstone marks an endpoint as removed so peers can clean up stale

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1851,8 +1851,16 @@ func (g *GravityClient) establishControlStreams() error {
 	}
 
 	for i, client := range g.sessionClients {
-		if i >= numConns {
-			break // Don't exceed allocated slice capacity
+		// Guard ALL slice accesses — during concurrent reconnection,
+		// slices may be shorter than expected.
+		if i >= numConns ||
+			i >= len(g.streamManager.contexts) ||
+			i >= len(g.streamManager.cancels) ||
+			i >= len(g.streamManager.controlStreams) ||
+			i >= len(g.streamManager.controlSendMu) {
+			g.logger.Warn("establishControlStreams: index %d exceeds slice capacity (conns=%d, ctx=%d, streams=%d), breaking",
+				i, numConns, len(g.streamManager.contexts), len(g.streamManager.controlStreams))
+			break
 		}
 		g.logger.Debug("establishing control stream %d/%d", i+1, len(g.connections))
 		ctx, cancel := context.WithCancel(g.ctx)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5884,7 +5884,7 @@ func (g *GravityClient) sendPing() {
 		return
 	}
 
-	if streams[0] == nil {
+	if len(streams) == 0 || streams[0] == nil {
 		g.logger.Debug("no control streams available for ping")
 		return
 	}

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4478,8 +4478,30 @@ func (g *GravityClient) parseGRPCURL(inputURL string) (string, error) {
 		u.Host = u.Host + ":443"
 	}
 
+	// Resolve the hostname via /etc/hosts first, then fall back to DNS.
+	// gRPC's built-in DNS resolver does not consult /etc/hosts, which causes
+	// connection failures in environments where /etc/hosts has the correct
+	// mapping but system DNS returns a different address (e.g., Lima VMs,
+	// containers with custom host entries).
+	hostname := u.Hostname()
+	port := u.Port()
+	if ip := resolveFromHostsFile(hostname); ip != "" {
+		resolved := net.JoinHostPort(ip, port)
+		g.logger.Debug("parsed gRPC URL: input=%s, resolved=%s (via /etc/hosts)", inputURL, resolved)
+		return resolved, nil
+	}
+
 	g.logger.Debug("parsed gRPC URL: input=%s, host=%s", inputURL, u.Host)
 	return u.Host, nil
+}
+
+// resolveFromHostsFile looks up a hostname in /etc/hosts (cached).
+// Returns the first matching IP address, or empty string if not found.
+func resolveFromHostsFile(hostname string) string {
+	if ip := dns.ResolveFromHostsFile(hostname); ip != nil {
+		return ip.String()
+	}
+	return ""
 }
 
 // extractHostnameFromURL extracts the hostname (without port) from a gRPC URL for TLS ServerName

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1833,16 +1833,27 @@ func (g *GravityClient) refreshEndpointHealth() {
 // establishControlStreams creates control streams for each connection
 func (g *GravityClient) establishControlStreams() error {
 	g.logger.Debug("creating control streams for %d connections", len(g.connections))
-	g.streamManager.controlStreams = make([]pb.GravitySessionService_EstablishSessionClient, len(g.connections))
-	g.streamManager.controlSendMu = make([]sync.Mutex, len(g.connections))
-	g.streamManager.contexts = make([]context.Context, len(g.connections))
-	g.streamManager.cancels = make([]context.CancelFunc, len(g.connections))
+	numConns := len(g.connections)
+	if numConns == 0 {
+		return fmt.Errorf("no gRPC connections available")
+	}
+	g.streamManager.controlStreams = make([]pb.GravitySessionService_EstablishSessionClient, numConns)
+	g.streamManager.controlSendMu = make([]sync.Mutex, numConns)
+	g.streamManager.contexts = make([]context.Context, numConns)
+	g.streamManager.cancels = make([]context.CancelFunc, numConns)
 
 	if g.multiEndpointMode.Load() {
 		return g.establishControlStreamsMulti()
 	}
 
+	if len(g.sessionClients) == 0 {
+		return fmt.Errorf("no session clients available")
+	}
+
 	for i, client := range g.sessionClients {
+		if i >= numConns {
+			break // Don't exceed allocated slice capacity
+		}
 		g.logger.Debug("establishing control stream %d/%d", i+1, len(g.connections))
 		ctx, cancel := context.WithCancel(g.ctx)
 		g.streamManager.contexts[i] = ctx

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4629,7 +4629,7 @@ func (g *GravityClient) sendOnStream(stream pb.GravitySessionService_EstablishSe
 }
 
 // SendRouteDeploymentRequest sends a route deployment request and waits for response (sync)
-func (g *GravityClient) SendRouteDeploymentRequest(deploymentID, virtualIP string, timeout time.Duration) (*pb.RouteDeploymentResponse, error) {
+func (g *GravityClient) SendRouteDeploymentRequest(deploymentID, virtualIP, ownerID string, timeout time.Duration) (*pb.RouteDeploymentResponse, error) {
 	// Read sessionReady under lock to avoid racing with reconnection
 	// which replaces the channel.
 	g.mu.RLock()
@@ -4669,6 +4669,7 @@ func (g *GravityClient) SendRouteDeploymentRequest(deploymentID, virtualIP strin
 			RouteDeployment: &pb.RouteDeploymentRequest{
 				DeploymentId: deploymentID,
 				VirtualIp:    virtualIP,
+				OwnerId:      ownerID,
 			},
 		},
 	}
@@ -4695,7 +4696,7 @@ func (g *GravityClient) SendRouteDeploymentRequest(deploymentID, virtualIP strin
 }
 
 // SendRouteSandboxRequest sends a route sandbox request and waits for response (sync)
-func (g *GravityClient) SendRouteSandboxRequest(sandboxID, virtualIP string, timeout time.Duration) (*pb.RouteSandboxResponse, error) {
+func (g *GravityClient) SendRouteSandboxRequest(sandboxID, virtualIP, ownerID string, timeout time.Duration) (*pb.RouteSandboxResponse, error) {
 	// Read sessionReady under lock to avoid racing with reconnection
 	// which replaces the channel.
 	g.mu.RLock()
@@ -4735,6 +4736,7 @@ func (g *GravityClient) SendRouteSandboxRequest(sandboxID, virtualIP string, tim
 			RouteSandbox: &pb.RouteSandboxRequest{
 				SandboxId: sandboxID,
 				VirtualIp: virtualIP,
+				OwnerId:   ownerID,
 			},
 		},
 	}
@@ -4807,12 +4809,15 @@ func (sm *StreamManager) releaseStream(stream *StreamInfo) {
 
 // Provider.Server interface implementations
 
-// Unprovision sends an unprovision request to the gravity server
-func (g *GravityClient) Unprovision(deploymentID string) error {
-	g.logger.Info("Unprovision: broadcasting removal of deployment %s to all endpoints", deploymentID)
+// Unprovision sends an unprovision request to the gravity server.
+// ownerID identifies the specific provision instance; gravity only removes the resource
+// if ownerID matches the current owner (empty ownerID = unconditional remove for backward compat).
+func (g *GravityClient) Unprovision(deploymentID string, ownerID string) error {
+	g.logger.Info("Unprovision: broadcasting removal of deployment %s (ownerID=%s) to all endpoints", deploymentID, ownerID)
 
 	req := &pb.UnprovisionRequest{
 		DeploymentId: deploymentID,
+		OwnerId:      ownerID,
 	}
 
 	msgID := generateMessageID()

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -2576,11 +2576,27 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	g.authorizationToken = response.MachineToken
 	g.connectionIDs = append(g.connectionIDs, response.MachineId)
 
-	g.otlpURL = response.OtlpUrl
-	g.otlpToken = response.OtlpKey
-	g.apiURL = response.ApiUrl
-	g.hostEnvironment = response.Environment
-	g.hostMapping = response.HostMapping
+	// Only update config values when non-empty. Multi-tunnel reuse sessions
+	// return minimal responses without these fields — don't overwrite the
+	// good config from the primary session.
+	g.logger.Info("[session-config] response: apiUrl=%q otlpUrl=%q env=%d hostMappings=%d machineId=%s server=%s",
+		response.ApiUrl, response.OtlpUrl, len(response.Environment), len(response.HostMapping), response.MachineId, response.GravityServer)
+	if response.OtlpUrl != "" {
+		g.otlpURL = response.OtlpUrl
+	}
+	if response.OtlpKey != "" {
+		g.otlpToken = response.OtlpKey
+	}
+	if response.ApiUrl != "" {
+		g.apiURL = response.ApiUrl
+	}
+	if len(response.Environment) > 0 {
+		g.hostEnvironment = response.Environment
+	}
+	if len(response.HostMapping) > 0 {
+		g.hostMapping = response.HostMapping
+	}
+	g.logger.Info("[session-config] effective: apiUrl=%q otlpUrl=%q hostMappings=%d", g.apiURL, g.otlpURL, len(g.hostMapping))
 
 	if len(response.SshPublicKey) > 0 {
 		g.logger.Trace("received SSH public key from Gravity (%d bytes)", len(response.SshPublicKey))

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -296,7 +296,18 @@ type GravityClient struct {
 	apiURL               string
 	hostMapping          []*pb.HostMapping
 	hostEnvironment      []string
-	once                 sync.Once
+	// Preserved session config fields — multi-tunnel reuse sessions send
+	// minimal responses without these. We store the values from the primary
+	// session and reuse them when subsequent responses are empty.
+	subnetRoutes      []string
+	machineSubnet     string
+	sessionHostname   string
+	sessionOrgID      string
+	machineToken      string
+	machineCertBundle string
+	sshPublicKey      []byte
+	signingPublicKey  []byte
+	once              sync.Once
 
 	// Messaging
 	evacuationCallback    func()
@@ -2596,14 +2607,31 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	if len(response.HostMapping) > 0 {
 		g.hostMapping = response.HostMapping
 	}
-	g.logger.Info("[session-config] effective: apiUrl=%q otlpUrl=%q hostMappings=%d", g.apiURL, g.otlpURL, len(g.hostMapping))
-
+	if len(response.SubnetRoutes) > 0 {
+		g.subnetRoutes = response.SubnetRoutes
+	}
+	if response.MachineSubnet != "" {
+		g.machineSubnet = response.MachineSubnet
+	}
+	if response.Hostname != "" {
+		g.sessionHostname = response.Hostname
+	}
+	if response.OrgId != "" {
+		g.sessionOrgID = response.OrgId
+	}
+	if response.MachineToken != "" {
+		g.machineToken = response.MachineToken
+	}
+	if response.MachineCertBundle != "" {
+		g.machineCertBundle = response.MachineCertBundle
+	}
 	if len(response.SshPublicKey) > 0 {
-		g.logger.Trace("received SSH public key from Gravity (%d bytes)", len(response.SshPublicKey))
+		g.sshPublicKey = response.SshPublicKey
 	}
 	if len(response.SigningPublicKey) > 0 {
-		g.logger.Trace("received signing public key from Gravity (%d bytes)", len(response.SigningPublicKey))
+		g.signingPublicKey = response.SigningPublicKey
 	}
+	g.logger.Info("[session-config] effective: apiUrl=%q otlpUrl=%q hostMappings=%d subnetRoutes=%d machineSubnet=%q", g.apiURL, g.otlpURL, len(g.hostMapping), len(g.subnetRoutes), g.machineSubnet)
 
 	g.mu.Unlock()
 
@@ -2633,9 +2661,9 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 
 	// Validate MachineSubnet if present. Empty is allowed for backward
 	// compatibility with ions that don't yet send it.
-	if response.MachineSubnet != "" {
-		if _, _, err := net.ParseCIDR(response.MachineSubnet); err != nil {
-			g.logger.Error("session hello returned invalid MachineSubnet %q: %v", response.MachineSubnet, err)
+	if g.machineSubnet != "" {
+		if _, _, err := net.ParseCIDR(g.machineSubnet); err != nil {
+			g.logger.Error("session hello returned invalid MachineSubnet %q: %v", g.machineSubnet, err)
 			signalConnectionID("")
 			closeSessionReady()
 			return
@@ -2649,21 +2677,21 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 		Context:           g.context,
 		Logger:            g.logger,
 		APIURL:            g.apiURL,
-		SSHPublicKey:      response.SshPublicKey,
+		SSHPublicKey:      g.sshPublicKey,
 		TelemetryURL:      g.otlpURL,
 		TelemetryAPIKey:   g.otlpToken,
 		GravityURL:        g.url,
 		AgentuityCACert:   g.caCert,
 		HostMapping:       g.hostMapping,
 		Environment:       g.hostEnvironment,
-		SubnetRoutes:      response.SubnetRoutes,
-		Hostname:          response.Hostname,
-		OrgID:             response.OrgId,
-		MachineToken:      response.MachineToken,
-		MachineID:         response.MachineId,
-		MachineCertBundle: response.MachineCertBundle,
-		MachineSubnet:     response.MachineSubnet,
-		SigningPublicKey:  response.SigningPublicKey,
+		SubnetRoutes:      g.subnetRoutes,
+		Hostname:          g.sessionHostname,
+		OrgID:             g.sessionOrgID,
+		MachineToken:      g.machineToken,
+		MachineID:         g.machineID,
+		MachineCertBundle: g.machineCertBundle,
+		MachineSubnet:     g.machineSubnet,
+		SigningPublicKey:  g.signingPublicKey,
 	}); err != nil {
 		g.logger.Error("error configuring provider after session hello: %v", err)
 		signalConnectionID("")
@@ -2672,9 +2700,9 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	}
 	g.logger.Debug("provider configured successfully")
 
-	g.logger.Debug("configuring subnet routing for routes %v", response.SubnetRoutes)
+	g.logger.Debug("configuring subnet routing for routes %v", g.subnetRoutes)
 	if g.networkInterface != nil {
-		if err := g.networkInterface.RouteTraffic(response.SubnetRoutes); err != nil {
+		if err := g.networkInterface.RouteTraffic(g.subnetRoutes); err != nil {
 			g.logger.Error("failed to route traffic for gravity subnet: %v", err)
 			signalConnectionID("")
 			closeSessionReady()

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -2642,7 +2642,8 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 		}
 	}
 
-	// Configure provider with session info
+	// Configure provider with session info. Use preserved values (g.*)
+	// for fields that multi-tunnel reuse sessions may leave empty.
 	if err := g.provider.Configure(provider.Configuration{
 		Server:            g,
 		Context:           g.context,
@@ -2650,7 +2651,7 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 		APIURL:            g.apiURL,
 		SSHPublicKey:      response.SshPublicKey,
 		TelemetryURL:      g.otlpURL,
-		TelemetryAPIKey:   response.OtlpKey,
+		TelemetryAPIKey:   g.otlpToken,
 		GravityURL:        g.url,
 		AgentuityCACert:   g.caCert,
 		HostMapping:       g.hostMapping,

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -2166,6 +2166,12 @@ func (g *GravityClient) sendSessionHello() error {
 
 	// Single-endpoint: send on primary control stream only (original path)
 	g.logger.Debug("sending session hello on primary control stream")
+	if len(g.streamManager.controlStreams) == 0 {
+		return fmt.Errorf("controlStreams not initialized")
+	}
+	if len(g.circuitBreakers) == 0 {
+		return fmt.Errorf("circuitBreakers not initialized")
+	}
 	stream := g.streamManager.controlStreams[0]
 	circuitBreaker := g.circuitBreakers[0]
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4339,6 +4339,9 @@ func (g *GravityClient) reconnectWithTimeout(timeout time.Duration) error {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				buf := make([]byte, 4096)
+				n := runtime.Stack(buf, false)
+				g.logger.Error("reconnection panicked: %v\nstack:\n%s", r, string(buf[:n]))
 				done <- fmt.Errorf("reconnection panicked: %v", r)
 			}
 		}()

--- a/gravity/grpc_interface_test.go
+++ b/gravity/grpc_interface_test.go
@@ -44,7 +44,7 @@ func TestUnprovisionMethodWithoutStreams(t *testing.T) {
 	}
 
 	// Test Unprovision with no streams should return error
-	err := server.Unprovision("test-deployment")
+	err := server.Unprovision("test-deployment", "")
 
 	if err == nil {
 		t.Error("Expected error for unprovision with no control streams")

--- a/gravity/proto/gravity_session.pb.go
+++ b/gravity/proto/gravity_session.pb.go
@@ -1122,6 +1122,7 @@ type RouteDeploymentRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"` // Unique identifier for the deployment
 	VirtualIp     string                 `protobuf:"bytes,3,opt,name=virtual_ip,json=virtualIp,proto3" json:"virtual_ip,omitempty"`          // Hadron virtual IP for the deployment
+	OwnerId       string                 `protobuf:"bytes,4,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`                // Provision owner ID — distinguishes container incarnations
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1166,6 +1167,13 @@ func (x *RouteDeploymentRequest) GetDeploymentId() string {
 func (x *RouteDeploymentRequest) GetVirtualIp() string {
 	if x != nil {
 		return x.VirtualIp
+	}
+	return ""
+}
+
+func (x *RouteDeploymentRequest) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
 	}
 	return ""
 }
@@ -1218,6 +1226,7 @@ func (x *RouteDeploymentResponse) GetIp() string {
 type UnprovisionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	DeploymentId  string                 `protobuf:"bytes,1,opt,name=deployment_id,json=deploymentId,proto3" json:"deployment_id,omitempty"` // Unique identifier of deployment to remove
+	OwnerId       string                 `protobuf:"bytes,2,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`                // Provision owner ID — only unprovision if this matches the current resource
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1255,6 +1264,13 @@ func (*UnprovisionRequest) Descriptor() ([]byte, []int) {
 func (x *UnprovisionRequest) GetDeploymentId() string {
 	if x != nil {
 		return x.DeploymentId
+	}
+	return ""
+}
+
+func (x *UnprovisionRequest) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
 	}
 	return ""
 }
@@ -1941,8 +1957,9 @@ type ExistingDeployment struct {
 	Paused         bool                   `protobuf:"varint,9,opt,name=paused,proto3" json:"paused,omitempty"`
 	PausedDuration *durationpb.Duration   `protobuf:"bytes,10,opt,name=pausedDuration,proto3" json:"pausedDuration,omitempty"`
 	OnDemand       bool                   `protobuf:"varint,11,opt,name=on_demand,json=onDemand,proto3" json:"on_demand,omitempty"`
-	Cert           string                 `protobuf:"bytes,12,opt,name=cert,proto3" json:"cert,omitempty"`                   // PEM certificate that was issued (just cert, ca + key not required)
-	PausedTimeout  *durationpb.Duration   `protobuf:"bytes,13,opt,name=pausedTimeout,proto3" json:"pausedTimeout,omitempty"` // Per-sandbox paused timeout (0 = infinite)
+	Cert           string                 `protobuf:"bytes,12,opt,name=cert,proto3" json:"cert,omitempty"`                      // PEM certificate that was issued (just cert, ca + key not required)
+	PausedTimeout  *durationpb.Duration   `protobuf:"bytes,13,opt,name=pausedTimeout,proto3" json:"pausedTimeout,omitempty"`    // Per-sandbox paused timeout (0 = infinite)
+	OwnerId        string                 `protobuf:"bytes,14,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"` // Unique per-provision owner ID — distinguishes container incarnations
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2059,6 +2076,13 @@ func (x *ExistingDeployment) GetPausedTimeout() *durationpb.Duration {
 		return x.PausedTimeout
 	}
 	return nil
+}
+
+func (x *ExistingDeployment) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
+	}
+	return ""
 }
 
 type ResourceRequirements struct {
@@ -2555,6 +2579,7 @@ type RouteSandboxRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
 	VirtualIp     string                 `protobuf:"bytes,2,opt,name=virtual_ip,json=virtualIp,proto3" json:"virtual_ip,omitempty"` // Hadron virtual IP for the sandbox
+	OwnerId       string                 `protobuf:"bytes,3,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`       // Provision owner ID — distinguishes container incarnations
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2599,6 +2624,13 @@ func (x *RouteSandboxRequest) GetSandboxId() string {
 func (x *RouteSandboxRequest) GetVirtualIp() string {
 	if x != nil {
 		return x.VirtualIp
+	}
+	return ""
+}
+
+func (x *RouteSandboxRequest) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
 	}
 	return ""
 }
@@ -3503,15 +3535,17 @@ const file_gravity_session_proto_rawDesc = "" +
 	"\x15provision_deployments\x18\x01 \x01(\bR\x14provisionDeployments\x127\n" +
 	"\x17unprovision_deployments\x18\x02 \x01(\bR\x16unprovisionDeployments\x126\n" +
 	"\x17dynamic_project_routing\x18\x03 \x01(\tR\x15dynamicProjectRouting\x12)\n" +
-	"\x10dynamic_hostname\x18\x04 \x01(\bR\x0fdynamicHostname\"b\n" +
+	"\x10dynamic_hostname\x18\x04 \x01(\bR\x0fdynamicHostname\"}\n" +
 	"\x16RouteDeploymentRequest\x12#\n" +
 	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12\x1d\n" +
 	"\n" +
-	"virtual_ip\x18\x03 \x01(\tR\tvirtualIpJ\x04\b\x02\x10\x03\")\n" +
+	"virtual_ip\x18\x03 \x01(\tR\tvirtualIp\x12\x19\n" +
+	"\bowner_id\x18\x04 \x01(\tR\aownerIdJ\x04\b\x02\x10\x03\")\n" +
 	"\x17RouteDeploymentResponse\x12\x0e\n" +
-	"\x02ip\x18\x01 \x01(\tR\x02ip\"9\n" +
+	"\x02ip\x18\x01 \x01(\tR\x02ip\"T\n" +
 	"\x12UnprovisionRequest\x12#\n" +
-	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\"G\n" +
+	"\rdeployment_id\x18\x01 \x01(\tR\fdeploymentId\x12\x19\n" +
+	"\bowner_id\x18\x02 \x01(\tR\aownerId\"G\n" +
 	"\vPingRequest\x128\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"H\n" +
 	"\fPongResponse\x128\n" +
@@ -3558,7 +3592,7 @@ const file_gravity_session_proto_rawDesc = "" +
 	" \x01(\tR\x06region\x12#\n" +
 	"\rinstance_type\x18\v \x01(\tR\finstanceType\x12#\n" +
 	"\rinstance_tags\x18\f \x03(\tR\finstanceTags\x12+\n" +
-	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\"\x8a\x04\n" +
+	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\"\xa5\x04\n" +
 	"\x12ExistingDeployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +
 	"\astarted\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\astarted\x12!\n" +
@@ -3572,7 +3606,8 @@ const file_gravity_session_proto_rawDesc = "" +
 	" \x01(\v2\x19.google.protobuf.DurationR\x0epausedDuration\x12\x1b\n" +
 	"\ton_demand\x18\v \x01(\bR\bonDemand\x12\x12\n" +
 	"\x04cert\x18\f \x01(\tR\x04cert\x12?\n" +
-	"\rpausedTimeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\rpausedTimeout\"\xe0\x01\n" +
+	"\rpausedTimeout\x18\r \x01(\v2\x19.google.protobuf.DurationR\rpausedTimeout\x12\x19\n" +
+	"\bowner_id\x18\x0e \x01(\tR\aownerId\"\xe0\x01\n" +
 	"\x14ResourceRequirements\x12!\n" +
 	"\fmemory_limit\x18\x01 \x01(\x03R\vmemoryLimit\x12\x1b\n" +
 	"\tcpu_limit\x18\x02 \x01(\x03R\bcpuLimit\x12%\n" +
@@ -3617,12 +3652,13 @@ const file_gravity_session_proto_rawDesc = "" +
 	"\vextra_hosts\x18\a \x03(\tR\n" +
 	"extraHosts\x12\x1f\n" +
 	"\vcert_bundle\x18\b \x01(\tR\n" +
-	"certBundle\"S\n" +
+	"certBundle\"n\n" +
 	"\x13RouteSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1d\n" +
 	"\n" +
-	"virtual_ip\x18\x02 \x01(\tR\tvirtualIp\"&\n" +
+	"virtual_ip\x18\x02 \x01(\tR\tvirtualIp\x12\x19\n" +
+	"\bowner_id\x18\x03 \x01(\tR\aownerId\"&\n" +
 	"\x14RouteSandboxResponse\x12\x0e\n" +
 	"\x02ip\x18\x01 \x01(\tR\x02ip\"\x81\x01\n" +
 	"\x16SandboxMetadataRequest\x12\x1d\n" +

--- a/gravity/proto/gravity_session.proto
+++ b/gravity/proto/gravity_session.proto
@@ -153,6 +153,7 @@ message RouteDeploymentRequest {
   string deployment_id = 1; // Unique identifier for the deployment
   reserved 2; // was: hostname (deprecated and removed)
   string virtual_ip = 3; // Hadron virtual IP for the deployment
+  string owner_id = 4; // Provision owner ID — distinguishes container incarnations
 }
 
 message RouteDeploymentResponse {
@@ -162,6 +163,7 @@ message RouteDeploymentResponse {
 // Unprovision request
 message UnprovisionRequest {
   string deployment_id = 1; // Unique identifier of deployment to remove
+  string owner_id = 2; // Provision owner ID — only unprovision if this matches the current resource
 }
 
 // Ping request for health checking
@@ -253,6 +255,7 @@ message ExistingDeployment {
   bool on_demand = 11;
   string cert = 12; // PEM certificate that was issued (just cert, ca + key not required)
   google.protobuf.Duration pausedTimeout = 13; // Per-sandbox paused timeout (0 = infinite)
+  string owner_id = 14; // Unique per-provision owner ID — distinguishes container incarnations
 }
 
 message ResourceRequirements {
@@ -325,6 +328,7 @@ message DeploymentMetadataResponse {
 message RouteSandboxRequest {
   string sandbox_id = 1;
   string virtual_ip = 2; // Hadron virtual IP for the sandbox
+  string owner_id = 3; // Provision owner ID — distinguishes container incarnations
 }
 
 message RouteSandboxResponse {

--- a/gravity/provider/provider.go
+++ b/gravity/provider/provider.go
@@ -9,8 +9,10 @@ import (
 
 // Server interface for gravity server communication
 type Server interface {
-	// Unprovision is called to inform the server that we are unprovisioning the deployment
-	Unprovision(deploymentID string) error
+	// Unprovision is called to inform the server that we are unprovisioning the deployment.
+	// ownerID identifies the specific provision instance; gravity only removes the resource
+	// if ownerID matches the current owner (empty ownerID = unconditional remove).
+	Unprovision(deploymentID string, ownerID string) error
 	// Pause is called to tell the server to pause sending provisioned events
 	Pause(reason string) error
 	// Resume is called to tell the server to resume sending provisioned events
@@ -69,12 +71,12 @@ type Configuration struct {
 type DeprovisionReason string
 
 const (
-	DeprovisionReasonIdleTimeout  DeprovisionReason = "idle_timeout"
+	DeprovisionReasonIdleTimeout   DeprovisionReason = "idle_timeout"
 	DeprovisionReasonPausedTimeout DeprovisionReason = "paused_timeout"
-	DeprovisionReasonError        DeprovisionReason = "error"
-	DeprovisionReasonExited       DeprovisionReason = "exit"
-	DeprovisionReasonShutdown     DeprovisionReason = "shutdown"
-	DeprovisionReasonUnprovision  DeprovisionReason = "unprovision"
+	DeprovisionReasonError         DeprovisionReason = "error"
+	DeprovisionReasonExited        DeprovisionReason = "exit"
+	DeprovisionReasonShutdown      DeprovisionReason = "shutdown"
+	DeprovisionReasonUnprovision   DeprovisionReason = "unprovision"
 )
 
 // Provider interface defines the minimal set of methods required by the gravity client

--- a/gravity/route_response_test.go
+++ b/gravity/route_response_test.go
@@ -163,7 +163,7 @@ func TestSendRouteSandboxRequest_ErrorFromServer(t *testing.T) {
 
 	errChan := make(chan error, 1)
 	go func() {
-		_, err := client.SendRouteSandboxRequest("sandbox-1", "fd00::1", time.Second)
+		_, err := client.SendRouteSandboxRequest("sandbox-1", "fd00::1", "", time.Second)
 		errChan <- err
 	}()
 
@@ -204,7 +204,7 @@ func TestSendRouteSandboxRequest_SuccessFromServer(t *testing.T) {
 
 	respChan := make(chan *pb.RouteSandboxResponse, 1)
 	go func() {
-		resp, err := client.SendRouteSandboxRequest("sandbox-1", "fd00::1", time.Second)
+		resp, err := client.SendRouteSandboxRequest("sandbox-1", "fd00::1", "", time.Second)
 		if err != nil {
 			respChan <- nil
 			return


### PR DESCRIPTION
## Summary
Multi-tunnel reuse sessions return minimal responses without ApiUrl, OtlpUrl, HostMapping, etc. Previously these empty values overwrote the good config from the primary session, causing the hadron to lose its API URL and fail to download deployment code.

Now only non-empty values update the stored config. Added debug logging for session config response and effective values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session settings from being unintentionally cleared during reconnect so endpoints, tokens, and session identity persist across handshakes.
  * Preserved primary session and machine identifiers (keys, certificates, routing info) across multi-tunnel reuse sessions.
  * Improved session-config logging to show incoming and effective configuration values.
  * Fixed errors when control streams or circuit breakers were uninitialized and improved ping handling when no control streams exist.

* **New Features**
  * Added optional SNI hostname support for endpoint mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->