### PR TITLE
feat: add auto-computed schema versioning to gossip structs

### DIFF
--- a/gravity/gossip/types.go
+++ b/gravity/gossip/types.go
@@ -1,9 +1,55 @@
 package gossip
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
+
+// Schema hashes — computed at init() from each struct's field names + types.
+// When a field is added, removed, or changes type, the hash changes
+// automatically. Receivers compare hashes to detect version mismatches
+// and apply defensive merge logic during rolling upgrades.
+//
+// Old peers that predate this field will produce V=0 (the JSON field is
+// omitted and Go defaults the uint8 to zero on unmarshal).
+var (
+	EndpointMappingV   uint8
+	EndpointTombstoneV uint8
+	NATEntryV          uint8
+	VIPHeartbeatV      uint8
+	SubnetRouteV       uint8
+)
+
+func init() {
+	EndpointMappingV = structHash(reflect.TypeOf(EndpointMapping{}))
+	EndpointTombstoneV = structHash(reflect.TypeOf(EndpointTombstone{}))
+	NATEntryV = structHash(reflect.TypeOf(NATEntry{}))
+	VIPHeartbeatV = structHash(reflect.TypeOf(VIPHeartbeat{}))
+	SubnetRouteV = structHash(reflect.TypeOf(SubnetRoute{}))
+}
+
+// structHash computes a stable uint8 fingerprint from the struct's exported
+// field names and types (excluding the V field itself). Any structural change
+// — adding, removing, or retyping a field — produces a different hash.
+func structHash(t reflect.Type) uint8 {
+	h := sha256.New()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() || f.Name == "V" {
+			continue // skip unexported fields and the version field itself
+		}
+		fmt.Fprintf(h, "%s:%s;", f.Name, f.Type.String())
+	}
+	sum := h.Sum(nil)
+	// Use first byte; 0 is reserved for legacy so map 0→1.
+	v := sum[0]
+	if v == 0 {
+		v = 1
+	}
+	return v
+}
 
 // MessageType identifies the kind of gossip message on the wire.
 type MessageType uint8
@@ -41,7 +87,15 @@ func (m MessageType) String() string {
 
 // EndpointMapping describes the mapping between a container and its network
 // endpoints within the Gravity mesh.
+//
+// VERSIONING: The V field is a structural hash computed at init() from the
+// field names and types of this struct. Any change to the struct layout
+// (adding, removing, or retyping a field) automatically changes V.
+// Receivers use V to detect schema mismatches during rolling upgrades
+// and apply defensive merge logic to avoid silent data loss.
+// Old peers that predate versioning will send V=0.
 type EndpointMapping struct {
+	V           uint8    `json:"v,omitempty"` // auto-computed structural hash; 0 = pre-versioning legacy
 	GravityVIP  string   `json:"gravity_vip"`
 	HadronVIP   string   `json:"hadron_vip"`
 	ContainerID string   `json:"container_id"`
@@ -54,7 +108,10 @@ type EndpointMapping struct {
 
 // EndpointTombstone marks an endpoint as removed so peers can clean up stale
 // mappings.
+//
+// VERSIONING: V is auto-computed. See EndpointMapping for details.
 type EndpointTombstone struct {
+	V           uint8  `json:"v,omitempty"` // auto-computed structural hash; 0 = pre-versioning legacy
 	ContainerID string `json:"container_id"`
 	MachineID   string `json:"machine_id"`
 	Timestamp   int64  `json:"timestamp"`
@@ -62,7 +119,10 @@ type EndpointTombstone struct {
 
 // NATEntry represents a single NAT translation entry used to route packets
 // between Gravity instances.
+//
+// VERSIONING: V is auto-computed. See EndpointMapping for details.
 type NATEntry struct {
+	V           uint8  `json:"v,omitempty"` // auto-computed structural hash; 0 = pre-versioning legacy
 	Key         string `json:"key"`
 	OriginalDst string `json:"original_dst"`
 	OriginalSrc string `json:"original_src"`
@@ -72,7 +132,10 @@ type NATEntry struct {
 }
 
 // VIPHeartbeat advertises ownership and recent changes for a VIP.
+//
+// VERSIONING: V is auto-computed. See EndpointMapping for details.
 type VIPHeartbeat struct {
+	V            uint8             `json:"v,omitempty"` // auto-computed structural hash; 0 = pre-versioning legacy
 	VIP          string            `json:"vip"`
 	Owners       map[string]int64  `json:"owners"`
 	Timestamp    int64             `json:"timestamp"`
@@ -82,17 +145,21 @@ type VIPHeartbeat struct {
 
 // SubnetRoute advertises ownership of a /64 subnet by a machine connected
 // to this ion instance. Used to build cross-ion forwarding tables.
+//
+// VERSIONING: V is auto-computed. See EndpointMapping for details.
 type SubnetRoute struct {
-	Subnet    string `json:"subnet"`     // /64 prefix, e.g. "fd15:d710:02:05:a1b2::/64"
-	MachineID string `json:"machine_id"` // Machine that owns this subnet
-	IonID     string `json:"ion_id"`     // Memberlist address of the ion that owns this subnet
-	Timestamp int64  `json:"timestamp"`  // Unix timestamp
-	Action    string `json:"action"`     // "add" or "remove"
+	V         uint8  `json:"v,omitempty"` // auto-computed structural hash; 0 = pre-versioning legacy
+	Subnet    string `json:"subnet"`      // /64 prefix, e.g. "fd15:d710:02:05:a1b2::/64"
+	MachineID string `json:"machine_id"`  // Machine that owns this subnet
+	IonID     string `json:"ion_id"`      // Memberlist address of the ion that owns this subnet
+	Timestamp int64  `json:"timestamp"`   // Unix timestamp
+	Action    string `json:"action"`      // "add" or "remove"
 }
 
 // Envelope is the wire format for gossip messages. It wraps a MessageType
 // together with a JSON-encoded payload so receivers can demux without
-// knowing the concrete type up front.
+// knowing the concrete type up front. Schema versioning is per-struct
+// (each payload carries its own V field), not per-envelope.
 type Envelope struct {
 	Type    MessageType     `json:"type"`
 	Payload json.RawMessage `json:"payload"`
@@ -116,21 +183,79 @@ func messageTypeFor(msg any) (MessageType, error) {
 	}
 }
 
+// stampVersion sets the V field on a gossip struct to its auto-computed
+// structural hash before serialization. Returns the (possibly copied) value
+// for marshaling and an error if the type is unhandled. This prevents new
+// gossip structs from being added to messageTypeFor without also being
+// handled here — Encode will return an error instead of silently sending
+// unversioned messages.
+func stampVersion(msg any) (any, error) {
+	switch m := msg.(type) {
+	case *EndpointMapping:
+		m.V = EndpointMappingV
+		return m, nil
+	case EndpointMapping:
+		m.V = EndpointMappingV
+		return m, nil
+	case *EndpointTombstone:
+		m.V = EndpointTombstoneV
+		return m, nil
+	case EndpointTombstone:
+		m.V = EndpointTombstoneV
+		return m, nil
+	case *NATEntry:
+		m.V = NATEntryV
+		return m, nil
+	case NATEntry:
+		m.V = NATEntryV
+		return m, nil
+	case *VIPHeartbeat:
+		m.V = VIPHeartbeatV
+		for i := range m.NewEndpoints {
+			m.NewEndpoints[i].V = EndpointMappingV
+		}
+		for i := range m.NewNATs {
+			m.NewNATs[i].V = NATEntryV
+		}
+		return m, nil
+	case VIPHeartbeat:
+		m.V = VIPHeartbeatV
+		for i := range m.NewEndpoints {
+			m.NewEndpoints[i].V = EndpointMappingV
+		}
+		for i := range m.NewNATs {
+			m.NewNATs[i].V = NATEntryV
+		}
+		return m, nil
+	case *SubnetRoute:
+		m.V = SubnetRouteV
+		return m, nil
+	case SubnetRoute:
+		m.V = SubnetRouteV
+		return m, nil
+	default:
+		return nil, fmt.Errorf("gossip: stampVersion: unhandled type %T — add it to stampVersion when adding new gossip structs", msg)
+	}
+}
+
 // Encode serialises msg into a JSON-encoded Envelope ready for the wire.
+// V is auto-stamped on the payload struct before marshaling. Returns an
+// error if the type is not handled by stampVersion, preventing new gossip
+// structs from silently sending unversioned messages.
 func Encode(msg any) ([]byte, error) {
 	mt, err := messageTypeFor(msg)
 	if err != nil {
 		return nil, err
 	}
-	payload, err := json.Marshal(msg)
+	stamped, err := stampVersion(msg)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(stamped)
 	if err != nil {
 		return nil, fmt.Errorf("gossip: marshal payload: %w", err)
 	}
-	env := Envelope{
-		Type:    mt,
-		Payload: payload,
-	}
-	return json.Marshal(env)
+	return json.Marshal(Envelope{Type: mt, Payload: payload})
 }
 
 // Decode deserialises a JSON-encoded Envelope and returns the MessageType

--- a/gravity/gossip/types_test.go
+++ b/gravity/gossip/types_test.go
@@ -2,6 +2,8 @@ package gossip
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -387,9 +389,17 @@ func TestEncodeDecode_RoundTrip(t *testing.T) {
 				t.Fatalf("type mismatch: got %v, want %v", gotTyp, tt.wantTyp)
 			}
 
-			// Re-encode decoded message and compare JSON to avoid deep-equal
-			// issues with nil vs empty slices/maps.
-			wantJSON, _ := json.Marshal(tt.msg)
+			// Re-encode the original through Encode (which stamps V) so both
+			// sides have the same schema version for comparison.
+			wantData, err := Encode(tt.msg)
+			if err != nil {
+				t.Fatalf("Encode want: %v", err)
+			}
+			_, wantMsg, err := Decode(wantData)
+			if err != nil {
+				t.Fatalf("Decode want: %v", err)
+			}
+			wantJSON, _ := json.Marshal(wantMsg)
 			gotJSON, _ := json.Marshal(gotMsg)
 
 			// Normalise by unmarshalling into maps.
@@ -463,6 +473,61 @@ func TestEncode_UnsupportedType(t *testing.T) {
 	_, err := Encode("not a gossip message")
 	if err == nil {
 		t.Fatal("expected error for unsupported type, got nil")
+	}
+}
+
+// TestEncode_UnsupportedStructReturnsError verifies that stampVersion returns
+// an error for struct types that are recognized by messageTypeFor but not
+// handled in stampVersion. This is tested indirectly — if someone adds a new
+// gossip struct to messageTypeFor but forgets stampVersion, Encode will fail.
+// We test with a raw struct that bypasses messageTypeFor to exercise the
+// stampVersion error path directly.
+func TestStampVersion_UnsupportedStructReturnsError(t *testing.T) {
+	type FakeGossipMsg struct {
+		Foo string `json:"foo"`
+	}
+	_, err := stampVersion(FakeGossipMsg{Foo: "bar"})
+	if err == nil {
+		t.Fatal("expected error from stampVersion for unhandled struct type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unhandled type") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestEncode_AllKnownTypesStampVersion(t *testing.T) {
+	// Every gossip struct that Encode accepts must have V stamped.
+	// This test ensures Encode + Decode produces V != 0 for all types.
+	msgs := []any{
+		EndpointMapping{ContainerID: "c1"},
+		EndpointTombstone{ContainerID: "c1"},
+		NATEntry{Key: "k1"},
+		VIPHeartbeat{VIP: "fd00::1"},
+		SubnetRoute{Subnet: "fd15::/64"},
+		// pointer variants
+		&EndpointMapping{ContainerID: "c2"},
+		&EndpointTombstone{ContainerID: "c2"},
+		&NATEntry{Key: "k2"},
+		&VIPHeartbeat{VIP: "fd00::2"},
+		&SubnetRoute{Subnet: "fd15:1::/64"},
+	}
+	for _, msg := range msgs {
+		data, err := Encode(msg)
+		if err != nil {
+			t.Fatalf("Encode(%T): %v", msg, err)
+		}
+		_, decoded, err := Decode(data)
+		if err != nil {
+			t.Fatalf("Decode(%T): %v", msg, err)
+		}
+		// Check V via reflection — all gossip structs have V as first field.
+		v := reflect.ValueOf(decoded).Elem().FieldByName("V")
+		if !v.IsValid() {
+			t.Fatalf("%T: missing V field", decoded)
+		}
+		if v.Uint() == 0 {
+			t.Errorf("%T: V = 0 after Encode/Decode, expected non-zero schema hash", decoded)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds structural hash versioning to all gossip payload structs to prevent silent data loss during rolling upgrades when old and new ions exchange gossip messages with different struct shapes.

## Problem

During rolling deploys, old ions (without newer fields like `SNIHostname`) gossip incomplete `EndpointMapping` records to new ions. The new ion's `addOrUpdate` blindly replaces its complete record with the incoming incomplete one — erasing fields the old ion doesn't know about.

## Solution

Each gossip struct (`EndpointMapping`, `EndpointTombstone`, `NATEntry`, `VIPHeartbeat`, `SubnetRoute`) gets a `V uint8` field whose value is **automatically computed at `init()` time** from a SHA-256 hash of the struct's field names and types:

- **No manual version bumping** — adding/removing/retyping a field automatically changes V
- **V=0 = legacy** — old peers that predate versioning send no V field (JSON `omitempty` defaults to 0)
- **`Encode()` auto-stamps V** before marshaling, including nested structs in `VIPHeartbeat`
- **`stampVersion()` returns error on unknown types** — prevents new gossip structs from silently sending unversioned messages
- **Backward compatible** — old peers ignore the unknown `v` JSON field

## How receivers use V

Ion's `addOrUpdate` (in a companion ion PR) uses `mergePreserveNonEmpty()` when updating an existing record — preserving non-empty string fields from the existing record that the incoming record has empty. This prevents old ions from erasing fields they don't know about, regardless of V. The V field enables logging and future per-version merge strategies.

## Changes

- `gravity/gossip/types.go`: Added `V` field to all 5 payload structs, `structHash()` for auto-computation, `stampVersion()` with error on unknown types, updated `Encode()` to auto-stamp
- `gravity/gossip/types_test.go`: Added `TestStampVersion_UnsupportedStructReturnsError`, `TestEncode_AllKnownTypesStampVersion`, fixed round-trip test for V stamping

## Testing

All existing tests pass. New tests verify:
- Unsupported struct types return error from `stampVersion`
- All known types get V stamped through `Encode`/`Decode` round-trip
- V is never 0 after encoding (0 reserved for legacy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented per-payload schema versioning for gossip messages to ensure proper validation and compatibility across protocol versions.

* **Tests**
  * Added comprehensive tests for schema versioning functionality and error handling for unsupported message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->