### PR TITLE
feat: add restart_count to HostInfo proto

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5982,6 +5982,7 @@ func getHostInfo(config GravityConfig) (*pb.HostInfo, error) {
 		Provider:         config.CloudProvider,
 		InstanceType:     config.InstanceType,
 		InstanceTags:     config.InstanceTags,
+		RestartCount:     config.RestartCount,
 	}, nil
 }
 

--- a/gravity/proto/gravity_session.pb.go
+++ b/gravity/proto/gravity_session.pb.go
@@ -1820,6 +1820,7 @@ type HostInfo struct {
 	InstanceType     string                 `protobuf:"bytes,11,opt,name=instance_type,json=instanceType,proto3" json:"instance_type,omitempty"`             // instance type of the client (n1-standard-32, m6i.8xlarge)
 	InstanceTags     []string               `protobuf:"bytes,12,rep,name=instance_tags,json=instanceTags,proto3" json:"instance_tags,omitempty"`             // tags on the instance
 	AvailabilityZone string                 `protobuf:"bytes,13,opt,name=availability_zone,json=availabilityZone,proto3" json:"availability_zone,omitempty"` // the availability zone for the client
+	RestartCount     uint32                 `protobuf:"varint,14,opt,name=restart_count,json=restartCount,proto3" json:"restart_count,omitempty"`            // systemd restart counter (0 = first start, >0 = crash-loop indicator)
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -1943,6 +1944,13 @@ func (x *HostInfo) GetAvailabilityZone() string {
 		return x.AvailabilityZone
 	}
 	return ""
+}
+
+func (x *HostInfo) GetRestartCount() uint32 {
+	if x != nil {
+		return x.RestartCount
+	}
+	return 0
 }
 
 type ExistingDeployment struct {
@@ -3576,7 +3584,7 @@ const file_gravity_session_proto_rawDesc = "" +
 	"\x1bConfigurationUpdateResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\asuccess\x18\x02 \x01(\bR\asuccess\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error\"\x90\x03\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xb5\x03\n" +
 	"\bHostInfo\x12\x18\n" +
 	"\astarted\x18\x01 \x01(\x04R\astarted\x12\x10\n" +
 	"\x03cpu\x18\x02 \x01(\rR\x03cpu\x12\x16\n" +
@@ -3592,7 +3600,8 @@ const file_gravity_session_proto_rawDesc = "" +
 	" \x01(\tR\x06region\x12#\n" +
 	"\rinstance_type\x18\v \x01(\tR\finstanceType\x12#\n" +
 	"\rinstance_tags\x18\f \x03(\tR\finstanceTags\x12+\n" +
-	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\"\xa5\x04\n" +
+	"\x11availability_zone\x18\r \x01(\tR\x10availabilityZone\x12#\n" +
+	"\rrestart_count\x18\x0e \x01(\rR\frestartCount\"\xa5\x04\n" +
 	"\x12ExistingDeployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +
 	"\astarted\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\astarted\x12!\n" +

--- a/gravity/proto/gravity_session.proto
+++ b/gravity/proto/gravity_session.proto
@@ -240,6 +240,7 @@ message HostInfo {
   string instance_type = 11; // instance type of the client (n1-standard-32, m6i.8xlarge)
   repeated string instance_tags = 12; // tags on the instance
   string availability_zone = 13; // the availability zone for the client
+  uint32 restart_count = 14; // systemd restart counter (0 = first start, >0 = crash-loop indicator)
 }
 
 message ExistingDeployment {

--- a/gravity/types.go
+++ b/gravity/types.go
@@ -52,6 +52,7 @@ type GravityConfig struct {
 	SkipAutoReconnect    bool
 	InstanceTags         []string // Tags for display only
 	InstanceType         string   // Type of instance (e.g., t2.micro)
+	RestartCount         uint32   // Systemd restart counter (0 = first start)
 	DefaultServerName    string   // Fallback TLS ServerName when connecting via IP address (default: "gravity.agentuity.com")
 	UseMultiConnect      bool     // Use multiple connections to gravity
 


### PR DESCRIPTION
## Summary

Adds `restart_count` (uint32, field 14) to the `HostInfo` protobuf message so hadron can report its systemd restart counter during the session hello.

## Why

We discovered `hadron-s6xljlx8` in us-west crash-looping every ~5 minutes (restart counter at 25+) due to a false-positive stall detection bug on idle machines with 0 containers. The companion hadron PR fixes the stall detection, but we need visibility into restart counts via the ion debug API so we can detect crash loops during health checks without SSH'ing into individual machines.

## Changes

- `gravity_session.proto`: Added `uint32 restart_count = 14` to `HostInfo`
- `gravity_session.pb.go`: Regenerated
- `gravity/grpc_client.go`: Populates `RestartCount` from `GravityConfig`
- `gravity/types.go`: Added `RestartCount uint32` to `GravityConfig`

Backward compatible — old hadrons send 0 (proto default), new hadrons send the systemd `NRestarts` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced system monitoring: Hosts now automatically track and report restart count information to the server during session initialization. This provides improved diagnostic capabilities to identify potential crash-loop conditions, better monitor system stability patterns, enhance operational troubleshooting workflows, and deliver more comprehensive visibility into overall platform health and reliability metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->