### PR TITLE
Fix stale Gravity peer discovery endpoint replacement

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1529,14 +1529,6 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 	g.logger.Debug("peer discovery: resolved %d URLs, connected to %d/%d",
 		len(allURLs), currentCount, maxPeers)
 
-	// If DNS doesn't expose more hosts than we are already connected to,
-	// there is nothing to rotate.
-	if len(allURLs) <= currentCount {
-		g.logger.Debug("peer discovery: full coverage (%d URLs, %d connections), no cycling needed",
-			len(allURLs), currentCount)
-		return
-	}
-
 	// Find URLs we're not currently connected to.
 	var newURLs []string
 	for _, u := range allURLs {
@@ -1585,6 +1577,14 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 		}
 		g.logger.Info("peer discovery: replacing stale connection %s (no longer in DNS) with %s", evictURL, newURL)
 		g.cycleEndpoint(evictURL, newURL)
+		return
+	}
+
+	// If DNS doesn't expose more hosts than we are already connected to and
+	// none of the active endpoints are stale, there is nothing to rotate.
+	if len(allURLs) <= currentCount {
+		g.logger.Debug("peer discovery: full coverage (%d URLs, %d connections), no cycling needed",
+			len(allURLs), currentCount)
 		return
 	}
 

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -298,8 +298,6 @@ func TestCheckPeerDiscovery_FullCoverage(t *testing.T) {
 
 func TestCheckPeerDiscovery_StaleURLReplaced(t *testing.T) {
 	// Connected to g1, g2, g3 but DNS returns g1, g2, g4, g5.
-	// The stale replacement path requires len(allURLs) > currentCount,
-	// so DNS must expose more hosts than we are connected to.
 	// g3 is stale (not in DNS) and should be replaced immediately.
 	connected := []string{
 		"grpc://g1.example.com",
@@ -333,6 +331,42 @@ func TestCheckPeerDiscovery_StaleURLReplaced(t *testing.T) {
 	}
 	if !urls["grpc://g4.example.com"] && !urls["grpc://g5.example.com"] {
 		t.Fatal("expected one of g4 or g5 to be added as replacement")
+	}
+}
+
+func TestCheckPeerDiscovery_StaleURLReplacedWhenResolvedCountMatchesConnectedCount(t *testing.T) {
+	// Connected to a stale bootstrap URL plus one correct ion URL.
+	// DNS now exposes the two correct direct ion URLs. Even though the
+	// resolved URL count matches the current connection count, the stale
+	// bootstrap URL must still be replaced.
+	connected := []string{
+		"grpc://bootstrap.example.com",
+		"grpc://ion-a.example.com",
+	}
+	g := newTestGravityClient(nil, connected)
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://ion-a.example.com",
+			"grpc://ion-b.example.com",
+		}
+	}
+	g.poolConfig.MaxGravityPeers = 2
+
+	g.checkPeerDiscovery(2 * time.Hour)
+
+	g.endpointsMu.RLock()
+	urls := make(map[string]bool)
+	for _, ep := range g.endpoints {
+		urls[ep.URL] = true
+	}
+	g.endpointsMu.RUnlock()
+
+	if urls["grpc://bootstrap.example.com"] {
+		t.Fatal("stale bootstrap endpoint was not replaced")
+	}
+	if !urls["grpc://ion-a.example.com"] || !urls["grpc://ion-b.example.com"] {
+		t.Fatalf("expected both direct ion endpoints after replacement, got %v", urls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace stale connected Gravity endpoints before the peer-discovery full-coverage early return
- add a regression test for the bootstrap+direct-ion mixed endpoint case
- keep the existing peer discovery and multi-connect behavior intact

## Testing
- go test ./gravity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced peer discovery logic to properly evaluate and replace stale endpoints before cycling decisions, improving connection stability.

## Tests
- Added test case validating stale endpoint replacement behavior in scenarios where resolved address count equals current connection count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->