### PR TITLE
Allow bound tunnel fallback during endpoint health lag

### DIFF
--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1661,6 +1661,42 @@ func TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconne
 	}
 }
 
+// TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale verifies
+// that response traffic can still use the endpoint it is already bound to when
+// endpoint health has gone stale but the tunnel stream itself is still healthy.
+// This covers the post-hello/post-tunnel reconnect window where
+// refreshEndpointHealth() may mark every endpoint unhealthy before the data
+// path has actually failed.
+func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t0", stream: &hardeningMockTunnelStream{}, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	stream, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+	if stream.connIndex != 0 {
+		t.Fatalf("expected bound stream from endpoint 0, got connIndex=%d", stream.connIndex)
+	}
+}
+
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1661,6 +1661,81 @@ func TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconne
 	}
 }
 
+// TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale verifies
+// that response traffic can still use the endpoint it is already bound to when
+// endpoint health has gone stale but the tunnel stream itself is still healthy.
+// This covers the post-hello/post-tunnel reconnect window where
+// refreshEndpointHealth() may mark every endpoint unhealthy before the data
+// path has actually failed.
+func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t0", stream: &hardeningMockTunnelStream{}, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	stream, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+	if stream.connIndex != 0 {
+		t.Fatalf("expected bound stream from endpoint 0, got connIndex=%d", stream.connIndex)
+	}
+}
+
+func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	key := ExtractFlowKey(pkt)
+	before := time.Now().Add(-2 * time.Second)
+	g.selector.mu.Lock()
+	g.selector.bindings[key].LastUsed = before
+	g.selector.mu.Unlock()
+
+	_, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+
+	g.selector.mu.RLock()
+	after := g.selector.bindings[key].LastUsed
+	g.selector.mu.RUnlock()
+	if !after.After(before) {
+		t.Fatalf("expected binding lastUsed to advance, before=%v after=%v", before, after)
+	}
+}
+
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1697,7 +1697,6 @@ func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testi
 	}
 }
 
-<<<<<<< HEAD
 func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing.T) {
 	t.Parallel()
 
@@ -1737,8 +1736,6 @@ func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing
 	}
 }
 
-=======
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5313,6 +5313,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
+				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+					g.logger.Debug("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
+					return fallbackStream, nil
+				}
 				// Log endpoint health summary for debugging selector failures.
 				var healthSummary []string
 				for i, ep := range endpoints {
@@ -5336,6 +5340,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.logger.Warn("endpoint %s has no healthy tunnels, marking unhealthy and triggering reconnect", endpoint.URL)
 			g.triggerEndpointReconnectByURL(endpoint.URL)
 			g.wakePeerDiscovery()
+		}
+		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+			g.logger.Debug("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
+			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
 	}
@@ -5368,6 +5376,33 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 	stream.loadCount++
 	stream.lastUsed = time.Now()
 	return stream, nil
+}
+
+func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *EndpointSelector) (*StreamInfo, string, bool) {
+	if selector == nil {
+		return nil, "", false
+	}
+
+	key := ExtractFlowKey(payload)
+	now := time.Now()
+
+	selector.mu.RLock()
+	binding, ok := selector.bindings[key]
+	selector.mu.RUnlock()
+	if !ok || binding == nil || binding.Endpoint == nil || now.Sub(binding.LastUsed) >= selector.ttl {
+		return nil, "", false
+	}
+
+	stream, err := g.selectStreamForEndpoint(payload, binding.Endpoint.URL)
+	if err != nil {
+		return nil, binding.Endpoint.URL, false
+	}
+	selector.mu.Lock()
+	if current, ok := selector.bindings[key]; ok && current == binding {
+		current.LastUsed = now
+	}
+	selector.mu.Unlock()
+	return stream, binding.Endpoint.URL, true
 }
 
 func (g *GravityClient) selectStreamForEndpoint(payload []byte, endpointURL string) (*StreamInfo, error) {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5313,6 +5313,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
+				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+					g.logger.Warn("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
+					return fallbackStream, nil
+				}
 				// Log endpoint health summary for debugging selector failures.
 				var healthSummary []string
 				for i, ep := range endpoints {
@@ -5336,6 +5340,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.logger.Warn("endpoint %s has no healthy tunnels, marking unhealthy and triggering reconnect", endpoint.URL)
 			g.triggerEndpointReconnectByURL(endpoint.URL)
 			g.wakePeerDiscovery()
+		}
+		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+			g.logger.Warn("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
+			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
 	}
@@ -5368,6 +5376,28 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 	stream.loadCount++
 	stream.lastUsed = time.Now()
 	return stream, nil
+}
+
+func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *EndpointSelector) (*StreamInfo, string, bool) {
+	if selector == nil {
+		return nil, "", false
+	}
+
+	key := ExtractFlowKey(payload)
+	now := time.Now()
+
+	selector.mu.RLock()
+	binding, ok := selector.bindings[key]
+	selector.mu.RUnlock()
+	if !ok || binding == nil || binding.Endpoint == nil || now.Sub(binding.LastUsed) >= selector.ttl {
+		return nil, "", false
+	}
+
+	stream, err := g.selectStreamForEndpoint(payload, binding.Endpoint.URL)
+	if err != nil {
+		return nil, binding.Endpoint.URL, false
+	}
+	return stream, binding.Endpoint.URL, true
 }
 
 func (g *GravityClient) selectStreamForEndpoint(payload []byte, endpointURL string) (*StreamInfo, error) {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5314,11 +5314,7 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
 				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
-<<<<<<< HEAD
 					g.logger.Debug("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
-=======
-					g.logger.Warn("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 					return fallbackStream, nil
 				}
 				// Log endpoint health summary for debugging selector failures.
@@ -5346,11 +5342,7 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.wakePeerDiscovery()
 		}
 		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
-<<<<<<< HEAD
 			g.logger.Debug("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
-=======
-			g.logger.Warn("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
@@ -5405,14 +5397,11 @@ func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *Endp
 	if err != nil {
 		return nil, binding.Endpoint.URL, false
 	}
-<<<<<<< HEAD
 	selector.mu.Lock()
 	if current, ok := selector.bindings[key]; ok && current == binding {
 		current.LastUsed = now
 	}
 	selector.mu.Unlock()
-=======
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 	return stream, binding.Endpoint.URL, true
 }
 


### PR DESCRIPTION
## Summary
- allow response traffic to use an already-bound healthy tunnel stream even when endpoint health has gone stale
- add a regression test for the reconnect window where all endpoints look unhealthy but the bound tunnel is still alive

## Problem
During reconnect, `refreshEndpointHealth()` can mark every endpoint unhealthy before the data path has actually failed. In that window, Hadron can receive Ion's `/_health` request over an existing tunnel, but `selectStreamForPacket()` returns `no healthy gravity endpoints` for the response because selector health is stale.

## Fix
If selector health yields no endpoint, or exhausts healthy endpoints, `selectStreamForPacket()` now checks the existing flow binding. If the bound endpoint still has a healthy tunnel stream, it uses that stream instead of failing.

## Testing
- `go test ./gravity`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Tests**
  * Added selector integration tests verifying bound-tunnel behavior when endpoint health is stale and that using the bound tunnel refreshes flow bindings.

* **Bug Fixes**
  * Enhanced stream selection to reuse an existing bound tunnel for active flows when endpoint health appears stale, preventing unnecessary failovers and preserving connectivity during transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->