### PR TITLE
Keep gravity reconnects on discovered endpoints

### DIFF
--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1661,6 +1661,42 @@ func TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconne
 	}
 }
 
+// TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale verifies
+// that response traffic can still use the endpoint it is already bound to when
+// endpoint health has gone stale but the tunnel stream itself is still healthy.
+// This covers the post-hello/post-tunnel reconnect window where
+// refreshEndpointHealth() may mark every endpoint unhealthy before the data
+// path has actually failed.
+func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t0", stream: &hardeningMockTunnelStream{}, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	stream, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+	if stream.connIndex != 0 {
+		t.Fatalf("expected bound stream from endpoint 0, got connIndex=%d", stream.connIndex)
+	}
+}
+
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1661,6 +1661,81 @@ func TestSelectStreamForPacket_MarksEndpointUnhealthy_TriggersPerEndpointReconne
 	}
 }
 
+// TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale verifies
+// that response traffic can still use the endpoint it is already bound to when
+// endpoint health has gone stale but the tunnel stream itself is still healthy.
+// This covers the post-hello/post-tunnel reconnect window where
+// refreshEndpointHealth() may mark every endpoint unhealthy before the data
+// path has actually failed.
+func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+		{connIndex: 1, isHealthy: false, streamID: "ep1-t0", stream: &hardeningMockTunnelStream{}, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	stream, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+	if stream.connIndex != 0 {
+		t.Fatalf("expected bound stream from endpoint 0, got connIndex=%d", stream.connIndex)
+	}
+}
+
+func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing.T) {
+	t.Parallel()
+
+	g := newWritePacketTestClient(t, 2)
+
+	g.endpoints[0].healthy.Store(false)
+	g.endpoints[1].healthy.Store(false)
+	g.streamManager.connectionHealth[0] = false
+	g.streamManager.connectionHealth[1] = false
+	g.streamManager.controlStreams[0] = &configurableMockStream{}
+	g.streamManager.controlStreams[1] = &configurableMockStream{}
+
+	boundStream := &hardeningMockTunnelStream{}
+	setupWritePacketStreams(g, []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "ep0-t0", stream: boundStream, lastUsed: time.Now()},
+	})
+
+	pkt := makeIPv6Packet()
+	preBindFlowToEndpoint(g, pkt, 0)
+
+	key := ExtractFlowKey(pkt)
+	before := time.Now().Add(-2 * time.Second)
+	g.selector.mu.Lock()
+	g.selector.bindings[key].LastUsed = before
+	g.selector.mu.Unlock()
+
+	_, err := g.selectStreamForPacket(pkt)
+	if err != nil {
+		t.Fatalf("expected bound healthy tunnel fallback, got: %v", err)
+	}
+
+	g.selector.mu.RLock()
+	after := g.selector.bindings[key].LastUsed
+	g.selector.mu.RUnlock()
+	if !after.After(before) {
+		t.Fatalf("expected binding lastUsed to advance, before=%v after=%v", before, after)
+	}
+}
+
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1697,7 +1697,6 @@ func TestSelectStreamForPacket_UsesBoundTunnelWhenEndpointHealthIsStale(t *testi
 	}
 }
 
-<<<<<<< HEAD
 func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing.T) {
 	t.Parallel()
 
@@ -1737,8 +1736,6 @@ func TestSelectStreamForPacket_BoundTunnelFallbackRefreshesBindingTTL(t *testing
 	}
 }
 
-=======
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 // --- Category D: Safety Net Edge Cases ---
 
 // TestTriggerAllEndpointReconnections_ClosingClient verifies that

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5313,6 +5313,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
+				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+					g.logger.Debug("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
+					return fallbackStream, nil
+				}
 				// Log endpoint health summary for debugging selector failures.
 				var healthSummary []string
 				for i, ep := range endpoints {
@@ -5336,6 +5340,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.logger.Warn("endpoint %s has no healthy tunnels, marking unhealthy and triggering reconnect", endpoint.URL)
 			g.triggerEndpointReconnectByURL(endpoint.URL)
 			g.wakePeerDiscovery()
+		}
+		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+			g.logger.Debug("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
+			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
 	}
@@ -5368,6 +5376,33 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 	stream.loadCount++
 	stream.lastUsed = time.Now()
 	return stream, nil
+}
+
+func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *EndpointSelector) (*StreamInfo, string, bool) {
+	if selector == nil {
+		return nil, "", false
+	}
+
+	key := ExtractFlowKey(payload)
+	now := time.Now()
+
+	selector.mu.RLock()
+	binding, ok := selector.bindings[key]
+	selector.mu.RUnlock()
+	if !ok || binding == nil || binding.Endpoint == nil || now.Sub(binding.LastUsed) >= selector.ttl {
+		return nil, "", false
+	}
+
+	stream, err := g.selectStreamForEndpoint(payload, binding.Endpoint.URL)
+	if err != nil {
+		return nil, binding.Endpoint.URL, false
+	}
+	selector.mu.Lock()
+	if current, ok := selector.bindings[key]; ok && current == binding {
+		current.LastUsed = now
+	}
+	selector.mu.Unlock()
+	return stream, binding.Endpoint.URL, true
 }
 
 func (g *GravityClient) selectStreamForEndpoint(payload []byte, endpointURL string) (*StreamInfo, error) {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5313,6 +5313,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 		for attempt := 0; attempt < len(endpoints); attempt++ {
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
+				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+					g.logger.Warn("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
+					return fallbackStream, nil
+				}
 				// Log endpoint health summary for debugging selector failures.
 				var healthSummary []string
 				for i, ep := range endpoints {
@@ -5336,6 +5340,10 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.logger.Warn("endpoint %s has no healthy tunnels, marking unhealthy and triggering reconnect", endpoint.URL)
 			g.triggerEndpointReconnectByURL(endpoint.URL)
 			g.wakePeerDiscovery()
+		}
+		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
+			g.logger.Warn("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
+			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
 	}
@@ -5368,6 +5376,28 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 	stream.loadCount++
 	stream.lastUsed = time.Now()
 	return stream, nil
+}
+
+func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *EndpointSelector) (*StreamInfo, string, bool) {
+	if selector == nil {
+		return nil, "", false
+	}
+
+	key := ExtractFlowKey(payload)
+	now := time.Now()
+
+	selector.mu.RLock()
+	binding, ok := selector.bindings[key]
+	selector.mu.RUnlock()
+	if !ok || binding == nil || binding.Endpoint == nil || now.Sub(binding.LastUsed) >= selector.ttl {
+		return nil, "", false
+	}
+
+	stream, err := g.selectStreamForEndpoint(payload, binding.Endpoint.URL)
+	if err != nil {
+		return nil, binding.Endpoint.URL, false
+	}
+	return stream, binding.Endpoint.URL, true
 }
 
 func (g *GravityClient) selectStreamForEndpoint(payload []byte, endpointURL string) (*StreamInfo, error) {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5314,11 +5314,7 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			endpoint := selector.Select(payload, endpoints)
 			if endpoint == nil {
 				if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
-<<<<<<< HEAD
 					g.logger.Debug("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
-=======
-					g.logger.Warn("selectStream: using bound endpoint %s despite unhealthy endpoint state because a healthy tunnel stream still exists", fallbackURL)
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 					return fallbackStream, nil
 				}
 				// Log endpoint health summary for debugging selector failures.
@@ -5346,11 +5342,7 @@ func (g *GravityClient) selectStreamForPacket(payload []byte) (*StreamInfo, erro
 			g.wakePeerDiscovery()
 		}
 		if fallbackStream, fallbackURL, ok := g.selectBoundTunnelFallback(payload, selector); ok {
-<<<<<<< HEAD
 			g.logger.Debug("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
-=======
-			g.logger.Warn("selectStream: using bound endpoint %s after selector exhausted healthy endpoint attempts because a healthy tunnel stream still exists", fallbackURL)
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 			return fallbackStream, nil
 		}
 		return nil, fmt.Errorf("no healthy tunnel streams on any endpoint")
@@ -5405,14 +5397,11 @@ func (g *GravityClient) selectBoundTunnelFallback(payload []byte, selector *Endp
 	if err != nil {
 		return nil, binding.Endpoint.URL, false
 	}
-<<<<<<< HEAD
 	selector.mu.Lock()
 	if current, ok := selector.bindings[key]; ok && current == binding {
 		current.LastUsed = now
 	}
 	selector.mu.Unlock()
-=======
->>>>>>> origin/fix/gravity-bound-tunnel-fallback
 	return stream, binding.Endpoint.URL, true
 }
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -3997,6 +3997,17 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 		port = "443"
 	}
 
+	// In multi-endpoint mode, prefer the discovered direct endpoint set over
+	// re-resolving the TLS server name. For IP-based endpoints, TLSServerName is
+	// often the shared bootstrap hostname used for SNI, not the direct per-ion
+	// hostname that discovery returned. Re-resolving TLSServerName can therefore
+	// collapse multiple direct endpoints back onto the same shared/NLB address.
+	if g.multiEndpointMode.Load() && g.discoveryResolveFunc != nil {
+		if newURL, handled := g.reResolveFromDiscoveredSet(endpointIndex, currentURL, inUse); handled {
+			return newURL
+		}
+	}
+
 	// Re-resolve the original hostname
 	lookupFn := g.dnsLookupMulti
 	if lookupFn == nil {
@@ -4079,6 +4090,62 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 
 	// All resolved IPs are identical to current — no change
 	return ""
+}
+
+func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL string, inUse map[string]bool) (string, bool) {
+	allURLs := g.discoveryResolveFunc()
+	if len(allURLs) == 0 {
+		return "", false
+	}
+
+	currentSet := make(map[string]struct{}, len(allURLs))
+	var currentKnown bool
+	for _, raw := range allURLs {
+		u := strings.TrimSpace(raw)
+		if u == "" {
+			continue
+		}
+		currentSet[u] = struct{}{}
+		if u == currentURL {
+			currentKnown = true
+		}
+	}
+	if len(currentSet) == 0 {
+		return "", false
+	}
+
+	// First try to switch to another discovered direct endpoint that is not
+	// already in use by a sibling endpoint.
+	for _, raw := range allURLs {
+		u := strings.TrimSpace(raw)
+		if u == "" || u == currentURL {
+			continue
+		}
+		parsed, err := g.parseGRPCURL(u)
+		if err != nil {
+			continue
+		}
+		host, _, splitErr := net.SplitHostPort(parsed)
+		if splitErr != nil || inUse[host] {
+			continue
+		}
+
+		g.endpointsMu.Lock()
+		if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
+			g.endpoints[endpointIndex].URL = u
+		}
+		g.endpointsMu.Unlock()
+		return u, true
+	}
+
+	// If the current endpoint is already part of the discovered direct set and
+	// there is no unique replacement, keep retrying it rather than falling back
+	// to the shared bootstrap/NLB hostname via TLSServerName DNS.
+	if currentKnown {
+		return "", true
+	}
+
+	return "", false
 }
 
 // probeHealthEndpoint checks if a gravity endpoint is alive and ready by

--- a/gravity/reresolve_test.go
+++ b/gravity/reresolve_test.go
@@ -196,6 +196,41 @@ func TestReResolveEndpointURL_PreservesCustomPort(t *testing.T) {
 	}
 }
 
+func TestReResolveEndpointURL_PrefersDiscoveredDirectEndpointsOverBootstrapDNS(t *testing.T) {
+	mock := newMockDNSLookup()
+	// The bootstrap/default server name resolves to a shared/NLB address.
+	mock.setIPs("gravity-bootstrap.example.com", "136.117.243.165")
+
+	endpoint0 := &GravityEndpoint{
+		URL:           "grpc://136.117.167.146:443",
+		TLSServerName: "gravity-bootstrap.example.com",
+	}
+	endpoint1 := &GravityEndpoint{
+		URL:           "grpc://136.118.131.90:443",
+		TLSServerName: "gravity-bootstrap.example.com",
+	}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1}, mock)
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://136.117.167.146:443",
+			"grpc://136.118.131.90:443",
+		}
+	}
+
+	newURL := g.reResolveEndpointURL(0, endpoint0.URL)
+
+	if newURL != "" {
+		t.Fatalf("expected no rewrite when discovered direct set already covers the endpoint pool, got %q", newURL)
+	}
+	if endpoint0.URL != "grpc://136.117.167.146:443" {
+		t.Fatalf("expected endpoint URL to remain on direct ion address, got %q", endpoint0.URL)
+	}
+	if mock.callCount() != 0 {
+		t.Fatalf("expected reconnect to avoid bootstrap DNS re-resolution, got %d lookup(s)", mock.callCount())
+	}
+}
+
 func TestReResolveEndpointURL_HandlesIPv6(t *testing.T) {
 	mock := newMockDNSLookup()
 	mock.setIPs("gravity.example.com", "fd15::2")


### PR DESCRIPTION
## Summary
- keep multi-endpoint Gravity reconnects on the discovered direct endpoint set
- avoid collapsing direct per-Ion endpoints back to the shared bootstrap/NLB address during reconnect
- add a regression test covering the direct-endpoint-to-bootstrap collapse case

## Validation
- go test ./gravity -run 'TestReResolveEndpointURL_PrefersDiscoveredDirectEndpointsOverBootstrapDNS|TestReResolveEndpointURL_'
- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced endpoint re-resolution logic to better handle multi-endpoint configurations by prioritizing discovered endpoints and reducing unnecessary DNS lookups.

* **Tests**
  * Added test coverage for endpoint re-resolution with discovered endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->