### PR TITLE
Keep gravity reconnects on discovered endpoints

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -3997,6 +3997,17 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 		port = "443"
 	}
 
+	// In multi-endpoint mode, prefer the discovered direct endpoint set over
+	// re-resolving the TLS server name. For IP-based endpoints, TLSServerName is
+	// often the shared bootstrap hostname used for SNI, not the direct per-ion
+	// hostname that discovery returned. Re-resolving TLSServerName can therefore
+	// collapse multiple direct endpoints back onto the same shared/NLB address.
+	if g.multiEndpointMode.Load() && g.discoveryResolveFunc != nil {
+		if newURL, handled := g.reResolveFromDiscoveredSet(endpointIndex, currentURL, inUse); handled {
+			return newURL
+		}
+	}
+
 	// Re-resolve the original hostname
 	lookupFn := g.dnsLookupMulti
 	if lookupFn == nil {
@@ -4079,6 +4090,62 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 
 	// All resolved IPs are identical to current — no change
 	return ""
+}
+
+func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL string, inUse map[string]bool) (string, bool) {
+	allURLs := g.discoveryResolveFunc()
+	if len(allURLs) == 0 {
+		return "", false
+	}
+
+	currentSet := make(map[string]struct{}, len(allURLs))
+	var currentKnown bool
+	for _, raw := range allURLs {
+		u := strings.TrimSpace(raw)
+		if u == "" {
+			continue
+		}
+		currentSet[u] = struct{}{}
+		if u == currentURL {
+			currentKnown = true
+		}
+	}
+	if len(currentSet) == 0 {
+		return "", false
+	}
+
+	// First try to switch to another discovered direct endpoint that is not
+	// already in use by a sibling endpoint.
+	for _, raw := range allURLs {
+		u := strings.TrimSpace(raw)
+		if u == "" || u == currentURL {
+			continue
+		}
+		parsed, err := g.parseGRPCURL(u)
+		if err != nil {
+			continue
+		}
+		host, _, splitErr := net.SplitHostPort(parsed)
+		if splitErr != nil || inUse[host] {
+			continue
+		}
+
+		g.endpointsMu.Lock()
+		if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
+			g.endpoints[endpointIndex].URL = u
+		}
+		g.endpointsMu.Unlock()
+		return u, true
+	}
+
+	// If the current endpoint is already part of the discovered direct set and
+	// there is no unique replacement, keep retrying it rather than falling back
+	// to the shared bootstrap/NLB hostname via TLSServerName DNS.
+	if currentKnown {
+		return "", true
+	}
+
+	return "", false
 }
 
 // probeHealthEndpoint checks if a gravity endpoint is alive and ready by

--- a/gravity/reresolve_test.go
+++ b/gravity/reresolve_test.go
@@ -196,6 +196,41 @@ func TestReResolveEndpointURL_PreservesCustomPort(t *testing.T) {
 	}
 }
 
+func TestReResolveEndpointURL_PrefersDiscoveredDirectEndpointsOverBootstrapDNS(t *testing.T) {
+	mock := newMockDNSLookup()
+	// The bootstrap/default server name resolves to a shared/NLB address.
+	mock.setIPs("gravity-bootstrap.example.com", "136.117.243.165")
+
+	endpoint0 := &GravityEndpoint{
+		URL:           "grpc://136.117.167.146:443",
+		TLSServerName: "gravity-bootstrap.example.com",
+	}
+	endpoint1 := &GravityEndpoint{
+		URL:           "grpc://136.118.131.90:443",
+		TLSServerName: "gravity-bootstrap.example.com",
+	}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1}, mock)
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://136.117.167.146:443",
+			"grpc://136.118.131.90:443",
+		}
+	}
+
+	newURL := g.reResolveEndpointURL(0, endpoint0.URL)
+
+	if newURL != "" {
+		t.Fatalf("expected no rewrite when discovered direct set already covers the endpoint pool, got %q", newURL)
+	}
+	if endpoint0.URL != "grpc://136.117.167.146:443" {
+		t.Fatalf("expected endpoint URL to remain on direct ion address, got %q", endpoint0.URL)
+	}
+	if mock.callCount() != 0 {
+		t.Fatalf("expected reconnect to avoid bootstrap DNS re-resolution, got %d lookup(s)", mock.callCount())
+	}
+}
+
 func TestReResolveEndpointURL_HandlesIPv6(t *testing.T) {
 	mock := newMockDNSLookup()
 	mock.setIPs("gravity.example.com", "fd15::2")


### PR DESCRIPTION
## Summary
- keep multi-endpoint Gravity reconnects on the discovered direct endpoint set
- avoid collapsing direct per-Ion endpoints back to the shared bootstrap/NLB address during reconnect
- add a regression test covering the direct-endpoint-to-bootstrap collapse case

## Validation
- go test ./gravity -run 'TestReResolveEndpointURL_PrefersDiscoveredDirectEndpointsOverBootstrapDNS|TestReResolveEndpointURL_'
- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced endpoint resolution logic to prioritize direct discovered endpoints during failover in multi-endpoint configurations, improving system reliability and reducing unnecessary DNS re-resolution attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->