### PR TITLE
Require healthy tunnel streams for endpoint routing

### DIFF
--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	pb "github.com/agentuity/go-common/gravity/proto"
 	"google.golang.org/grpc"
@@ -235,6 +236,7 @@ func TestEstablishTunnelStreams_SkipsNilClients(t *testing.T) {
 	g.helloAckedStreams.Store(2, true)
 
 	go func() {
+		time.Sleep(20 * time.Millisecond)
 		g.connectionIDChan <- "machine-1"
 		g.connectionIDChan <- "machine-1"
 	}()

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -2265,9 +2265,10 @@ func TestTunnelLiveness_AllEndpointsStale_OnlyReconnectsFirst(t *testing.T) {
 
 // TestDisconnectEndpointStreams_RefreshesHealth verifies that
 // disconnectEndpointStreams calls refreshEndpointHealth, which re-derives
-// endpoint health from connectionHealth. This is the critical discovery:
-// if tests set endpoint.healthy=false but leave connectionHealth=true,
-// refreshEndpointHealth will override the test's intent.
+// endpoint health from connectionHealth plus the presence of a healthy tunnel
+// stream. Tests that manipulate endpoint health directly must also consider
+// the underlying control/tunnel state or refreshEndpointHealth will overwrite
+// the manual change.
 func TestDisconnectEndpointStreams_RefreshesHealth(t *testing.T) {
 	t.Parallel()
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1820,6 +1820,18 @@ func (g *GravityClient) refreshEndpointHealth() {
 	copy(connectionHealth, g.streamManager.connectionHealth)
 	g.streamManager.healthMu.RUnlock()
 
+	healthyTunnelByConn := make([]bool, len(connectionHealth))
+	g.streamManager.tunnelMu.RLock()
+	for _, streamInfo := range g.streamManager.tunnelStreams {
+		if streamInfo == nil || !streamInfo.isHealthy {
+			continue
+		}
+		if streamInfo.connIndex >= 0 && streamInfo.connIndex < len(healthyTunnelByConn) {
+			healthyTunnelByConn[streamInfo.connIndex] = true
+		}
+	}
+	g.streamManager.tunnelMu.RUnlock()
+
 	g.mu.RLock()
 	connectionURLs := make([]string, len(g.connectionURLs))
 	copy(connectionURLs, g.connectionURLs)
@@ -1831,7 +1843,7 @@ func (g *GravityClient) refreshEndpointHealth() {
 			if endpointURL != endpoint.URL {
 				continue
 			}
-			if connIndex >= 0 && connIndex < len(connectionHealth) && connectionHealth[connIndex] {
+			if connIndex >= 0 && connIndex < len(connectionHealth) && connectionHealth[connIndex] && healthyTunnelByConn[connIndex] {
 				healthy = true
 				break
 			}
@@ -4448,13 +4460,6 @@ func (g *GravityClient) reconnectSingleEndpoint(endpointIndex int, endpointURL s
 	for _, s := range streamsToStart {
 		go g.handleTunnelStream(s.idx, s.stream, s.streamID)
 	}
-
-	g.endpointsMu.RLock()
-	if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
-		g.endpoints[endpointIndex].healthy.Store(true)
-		g.endpoints[endpointIndex].lastHeartbeat.Store(time.Now().Unix())
-	}
-	g.endpointsMu.RUnlock()
 
 	g.rebuildEndpointStreamIndices()
 	g.refreshEndpointHealth()

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1820,6 +1820,15 @@ func (g *GravityClient) refreshEndpointHealth() {
 	copy(connectionHealth, g.streamManager.connectionHealth)
 	g.streamManager.healthMu.RUnlock()
 
+	healthyControlByConn := make([]bool, len(connectionHealth))
+	g.streamManager.controlMu.RLock()
+	for connIndex := range healthyControlByConn {
+		if connIndex >= 0 && connIndex < len(g.streamManager.controlStreams) && g.streamManager.controlStreams[connIndex] != nil {
+			healthyControlByConn[connIndex] = true
+		}
+	}
+	g.streamManager.controlMu.RUnlock()
+
 	healthyTunnelByConn := make([]bool, len(connectionHealth))
 	g.streamManager.tunnelMu.RLock()
 	for _, streamInfo := range g.streamManager.tunnelStreams {
@@ -1843,7 +1852,10 @@ func (g *GravityClient) refreshEndpointHealth() {
 			if endpointURL != endpoint.URL {
 				continue
 			}
-			if connIndex >= 0 && connIndex < len(connectionHealth) && connectionHealth[connIndex] && healthyTunnelByConn[connIndex] {
+			if connIndex >= 0 && connIndex < len(connectionHealth) &&
+				connectionHealth[connIndex] &&
+				healthyControlByConn[connIndex] &&
+				healthyTunnelByConn[connIndex] {
 				healthy = true
 				break
 			}

--- a/gravity/hardening_test.go
+++ b/gravity/hardening_test.go
@@ -1477,7 +1477,8 @@ func TestPerformHealthCheck_StreamRecovery_OnlyWhenConnectionReady(t *testing.T)
 }
 
 func TestRefreshEndpointHealth_DerivedFromConnectionHealth(t *testing.T) {
-	// refreshEndpointHealth derives endpoint health from connectionHealth.
+	// refreshEndpointHealth derives endpoint health from control-plane health
+	// plus the presence of at least one healthy tunnel stream for that endpoint.
 	// Verify the derivation is correct for mixed healthy/unhealthy connections.
 	g := newHardeningGravityClient(t, 2)
 
@@ -1497,11 +1498,17 @@ func TestRefreshEndpointHealth_DerivedFromConnectionHealth(t *testing.T) {
 	g.streamManager.healthMu.Lock()
 	g.streamManager.connectionHealth = []bool{true, false} // conn 0 healthy, conn 1 unhealthy
 	g.streamManager.healthMu.Unlock()
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+	}
+	g.streamManager.tunnelMu.Unlock()
 
 	g.refreshEndpointHealth()
 
 	if !ep0.healthy.Load() {
-		t.Fatal("endpoint 0 should be healthy (connection 0 is healthy)")
+		t.Fatal("endpoint 0 should be healthy (connection 0 and a tunnel stream are healthy)")
 	}
 	if ep1.healthy.Load() {
 		t.Fatal("endpoint 1 should be unhealthy (connection 1 is unhealthy)")
@@ -1509,7 +1516,8 @@ func TestRefreshEndpointHealth_DerivedFromConnectionHealth(t *testing.T) {
 }
 
 func TestRefreshEndpointHealth_AllUnhealthy(t *testing.T) {
-	// When all connections are unhealthy, all endpoints should be unhealthy.
+	// When all connections are unhealthy, all endpoints should be unhealthy
+	// even if tunnel stream entries are present.
 	g := newHardeningGravityClient(t, 3)
 
 	eps := make([]*GravityEndpoint, 3)
@@ -1532,6 +1540,13 @@ func TestRefreshEndpointHealth_AllUnhealthy(t *testing.T) {
 	g.streamManager.healthMu.Lock()
 	g.streamManager.connectionHealth = []bool{false, false, false}
 	g.streamManager.healthMu.Unlock()
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+		{connIndex: 2, isHealthy: true, streamID: "s2"},
+	}
+	g.streamManager.tunnelMu.Unlock()
 
 	g.refreshEndpointHealth()
 
@@ -1539,6 +1554,42 @@ func TestRefreshEndpointHealth_AllUnhealthy(t *testing.T) {
 		if ep.healthy.Load() {
 			t.Fatalf("endpoint %d should be unhealthy (all connections unhealthy)", i)
 		}
+	}
+}
+
+func TestRefreshEndpointHealth_RequiresHealthyTunnelStream(t *testing.T) {
+	g := newHardeningGravityClient(t, 2)
+
+	ep0 := &GravityEndpoint{URL: "grpc://10.0.0.1:443"}
+	ep1 := &GravityEndpoint{URL: "grpc://10.0.0.2:443"}
+
+	g.endpointsMu.Lock()
+	g.endpoints = []*GravityEndpoint{ep0, ep1}
+	g.endpointsMu.Unlock()
+
+	g.mu.Lock()
+	g.connectionURLs = []string{"grpc://10.0.0.1:443", "grpc://10.0.0.2:443"}
+	g.mu.Unlock()
+
+	g.streamManager.healthMu.Lock()
+	g.streamManager.connectionHealth = []bool{true, true}
+	g.streamManager.healthMu.Unlock()
+
+	// Endpoint 0 only has an unhealthy tunnel; endpoint 1 has a healthy one.
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: false, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
+	g.refreshEndpointHealth()
+
+	if ep0.healthy.Load() {
+		t.Fatal("endpoint 0 should remain unhealthy without a healthy tunnel stream")
+	}
+	if !ep1.healthy.Load() {
+		t.Fatal("endpoint 1 should be healthy with a healthy connection and tunnel stream")
 	}
 }
 

--- a/gravity/hardening_test.go
+++ b/gravity/hardening_test.go
@@ -1498,6 +1498,12 @@ func TestRefreshEndpointHealth_DerivedFromConnectionHealth(t *testing.T) {
 	g.streamManager.healthMu.Lock()
 	g.streamManager.connectionHealth = []bool{true, false} // conn 0 healthy, conn 1 unhealthy
 	g.streamManager.healthMu.Unlock()
+	g.streamManager.controlMu.Lock()
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&configurableMockStream{},
+		&configurableMockStream{},
+	}
+	g.streamManager.controlMu.Unlock()
 	g.streamManager.tunnelMu.Lock()
 	g.streamManager.tunnelStreams = []*StreamInfo{
 		{connIndex: 0, isHealthy: true, streamID: "s0"},
@@ -1540,6 +1546,13 @@ func TestRefreshEndpointHealth_AllUnhealthy(t *testing.T) {
 	g.streamManager.healthMu.Lock()
 	g.streamManager.connectionHealth = []bool{false, false, false}
 	g.streamManager.healthMu.Unlock()
+	g.streamManager.controlMu.Lock()
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&configurableMockStream{},
+		&configurableMockStream{},
+		&configurableMockStream{},
+	}
+	g.streamManager.controlMu.Unlock()
 	g.streamManager.tunnelMu.Lock()
 	g.streamManager.tunnelStreams = []*StreamInfo{
 		{connIndex: 0, isHealthy: true, streamID: "s0"},
@@ -1574,6 +1587,12 @@ func TestRefreshEndpointHealth_RequiresHealthyTunnelStream(t *testing.T) {
 	g.streamManager.healthMu.Lock()
 	g.streamManager.connectionHealth = []bool{true, true}
 	g.streamManager.healthMu.Unlock()
+	g.streamManager.controlMu.Lock()
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&configurableMockStream{},
+		&configurableMockStream{},
+	}
+	g.streamManager.controlMu.Unlock()
 
 	// Endpoint 0 only has an unhealthy tunnel; endpoint 1 has a healthy one.
 	g.streamManager.tunnelMu.Lock()
@@ -1590,6 +1609,48 @@ func TestRefreshEndpointHealth_RequiresHealthyTunnelStream(t *testing.T) {
 	}
 	if !ep1.healthy.Load() {
 		t.Fatal("endpoint 1 should be healthy with a healthy connection and tunnel stream")
+	}
+}
+
+func TestRefreshEndpointHealth_RequiresControlStream(t *testing.T) {
+	g := newHardeningGravityClient(t, 2)
+
+	ep0 := &GravityEndpoint{URL: "grpc://10.0.0.1:443"}
+	ep1 := &GravityEndpoint{URL: "grpc://10.0.0.2:443"}
+
+	g.endpointsMu.Lock()
+	g.endpoints = []*GravityEndpoint{ep0, ep1}
+	g.endpointsMu.Unlock()
+
+	g.mu.Lock()
+	g.connectionURLs = []string{"grpc://10.0.0.1:443", "grpc://10.0.0.2:443"}
+	g.mu.Unlock()
+
+	g.streamManager.healthMu.Lock()
+	g.streamManager.connectionHealth = []bool{true, true}
+	g.streamManager.healthMu.Unlock()
+
+	g.streamManager.controlMu.Lock()
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		nil,
+		&configurableMockStream{},
+	}
+	g.streamManager.controlMu.Unlock()
+
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{connIndex: 0, isHealthy: true, streamID: "s0"},
+		{connIndex: 1, isHealthy: true, streamID: "s1"},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
+	g.refreshEndpointHealth()
+
+	if ep0.healthy.Load() {
+		t.Fatal("endpoint 0 should remain unhealthy without a control stream")
+	}
+	if !ep1.healthy.Load() {
+		t.Fatal("endpoint 1 should be healthy with connection, control stream, and tunnel stream")
 	}
 }
 


### PR DESCRIPTION
## Summary
- require a healthy tunnel stream before an endpoint is considered healthy for packet routing
- remove the transient early-healthy reconnect window so endpoints are only routable after refreshEndpointHealth confirms control plus tunnel health
- add regression coverage for endpoint health derivation and the reconnect path

## Validation
- go test ./gravity
- local multi-endpoint Hadron validation against 3 explicit local Ion endpoints
  - clean startup on all 3 endpoints
  - clean recovery after restarting one Ion
  - no `no healthy tunnel streams` reconnect loop observed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint health logic refined: endpoints are considered healthy only when connection health, an active control stream, and at least one healthy tunnel stream are present.

* **Tests**
  * Updated and added tests to validate the enhanced endpoint health evaluation and control-stream resilience; timing in resilience test adjusted to ensure stable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->