### PR TITLE
Reconnect cycled gravity endpoints immediately

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -244,6 +244,7 @@ type GravityClient struct {
 	peerDiscoveryWake     chan struct{} // non-blocking signal to wake the discovery loop immediately
 	discoveryCtx          context.Context
 	discoveryCancel       context.CancelFunc
+	initialStartupDone    atomic.Bool
 
 	// dnsLookupMulti is the function used to resolve hostnames during
 	// endpoint re-resolution. Defaults to dns.DefaultDNS.LookupMulti.
@@ -931,17 +932,15 @@ func (g *GravityClient) startMultiEndpoint() error {
 		g.streamManager.connectionHealth[i] = true
 	}
 
-	// Start peer discovery only after per-endpoint reconnect state is sized.
-	// peerDiscoveryLoop can schedule reconnects immediately via addEndpoint()
-	// and cycleEndpoint(), so the reconnect guard slices must already exist.
+	// Cancel any prior discovery loop before beginning a fresh startup attempt.
+	// Peer discovery is launched only after the initial multi-endpoint startup
+	// completes successfully, so it cannot race establishControlStreams,
+	// sendSessionHello, or establishTunnelStreams.
+	g.initialStartupDone.Store(false)
 	if g.discoveryCancel != nil {
 		g.discoveryCancel()
 		g.discoveryCtx = nil
 		g.discoveryCancel = nil
-	}
-	if g.discoveryResolveFunc != nil {
-		g.discoveryCtx, g.discoveryCancel = context.WithCancel(g.ctx)
-		go g.peerDiscoveryLoop(g.discoveryCtx)
 	}
 
 	g.logger.Debug("establishing %d gRPC connections", connectionCount)
@@ -1061,9 +1060,19 @@ func (g *GravityClient) startMultiEndpoint() error {
 	g.rebuildEndpointStreamIndices()
 	g.refreshEndpointHealth()
 
+	var discoveryCtx context.Context
 	g.mu.Lock()
 	g.connected = true
+	g.initialStartupDone.Store(true)
+	if g.discoveryResolveFunc != nil {
+		g.discoveryCtx, g.discoveryCancel = context.WithCancel(g.ctx)
+		discoveryCtx = g.discoveryCtx
+	}
 	g.mu.Unlock()
+
+	if discoveryCtx != nil {
+		go g.peerDiscoveryLoop(discoveryCtx)
+	}
 
 	for _, endpointIndex := range g.tunnelReadyEndpointIndices() {
 		g.fireOnEndpointTunnelReady(endpointIndex)
@@ -1519,6 +1528,9 @@ func (g *GravityClient) countHealthyEndpoints() int {
 }
 
 func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
+	if !g.initialStartupDone.Load() {
+		return
+	}
 	if g.discoveryResolveFunc == nil {
 		return
 	}
@@ -4769,7 +4781,14 @@ func (g *GravityClient) reconnect() error {
 	g.ensureConnectionContextLocked()
 	g.connected = false
 	g.closing = false // Reset closing flag to allow reconnection
+	g.initialStartupDone.Store(false)
 	g.sessionReady = make(chan struct{})
+
+	if g.discoveryCancel != nil {
+		g.discoveryCancel()
+		g.discoveryCtx = nil
+		g.discoveryCancel = nil
+	}
 
 	// Clear connection IDs from previous connection
 	g.connectionIDs = make([]string, 0, g.poolConfig.PoolSize)
@@ -4888,6 +4907,7 @@ func (g *GravityClient) cleanup() {
 		g.discoveryCtx = nil
 		g.discoveryCancel = nil
 	}
+	g.initialStartupDone.Store(false)
 
 	// Cancel all stream contexts
 	for _, cancel := range g.streamManager.cancels {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -244,6 +244,8 @@ type GravityClient struct {
 	peerDiscoveryWake     chan struct{} // non-blocking signal to wake the discovery loop immediately
 	discoveryCtx          context.Context
 	discoveryCancel       context.CancelFunc
+	discoveryDone         chan struct{}
+	discoveryMu           sync.Mutex
 	initialStartupDone    atomic.Bool
 
 	// dnsLookupMulti is the function used to resolve hostnames during
@@ -799,6 +801,8 @@ func (g *GravityClient) startMultiEndpoint() error {
 
 	g.logger.Info("multi-endpoint mode: connecting to %d Gravity servers: %v", len(urls), urls)
 
+	g.stopPeerDiscovery()
+
 	g.endpointsMu.Lock()
 	g.endpoints = make([]*GravityEndpoint, 0)
 	var errs []error
@@ -937,11 +941,6 @@ func (g *GravityClient) startMultiEndpoint() error {
 	// completes successfully, so it cannot race establishControlStreams,
 	// sendSessionHello, or establishTunnelStreams.
 	g.initialStartupDone.Store(false)
-	if g.discoveryCancel != nil {
-		g.discoveryCancel()
-		g.discoveryCtx = nil
-		g.discoveryCancel = nil
-	}
 
 	g.logger.Debug("establishing %d gRPC connections", connectionCount)
 	for i := range connectionCount {
@@ -1060,19 +1059,12 @@ func (g *GravityClient) startMultiEndpoint() error {
 	g.rebuildEndpointStreamIndices()
 	g.refreshEndpointHealth()
 
-	var discoveryCtx context.Context
 	g.mu.Lock()
 	g.connected = true
 	g.initialStartupDone.Store(true)
-	if g.discoveryResolveFunc != nil {
-		g.discoveryCtx, g.discoveryCancel = context.WithCancel(g.ctx)
-		discoveryCtx = g.discoveryCtx
-	}
 	g.mu.Unlock()
 
-	if discoveryCtx != nil {
-		go g.peerDiscoveryLoop(discoveryCtx)
-	}
+	g.startPeerDiscovery()
 
 	for _, endpointIndex := range g.tunnelReadyEndpointIndices() {
 		g.fireOnEndpointTunnelReady(endpointIndex)
@@ -1448,7 +1440,11 @@ func (g *GravityClient) bindingCleanupLoop() {
 	}
 }
 
-func (g *GravityClient) peerDiscoveryLoop(ctx context.Context) {
+func (g *GravityClient) peerDiscoveryLoop(ctx context.Context, done chan struct{}) {
+	defer func() {
+		close(done)
+	}()
+
 	idleInterval := g.peerDiscoveryInterval
 	if idleInterval <= 0 {
 		idleInterval = DefaultPeerDiscoveryInterval
@@ -1698,13 +1694,19 @@ func (g *GravityClient) cycleEndpoint(oldURL, newURL string) {
 
 	g.mu.Lock()
 	if oldIdx >= 0 && oldIdx < len(g.connectionURLs) {
-		g.connectionURLs[oldIdx] = newURL
+		g.connectionURLs[oldIdx] = ""
 	}
 	g.mu.Unlock()
 
 	g.logger.Info("peer discovery: endpoint cycled: removed %s, added %s", oldURL, newURL)
 	g.disconnectEndpointStreams(oldIdx)
 	g.scheduleEndpointReconnect(oldIdx, "peer_discovery_cycle")
+
+	g.mu.Lock()
+	if oldIdx >= 0 && oldIdx < len(g.connectionURLs) {
+		g.connectionURLs[oldIdx] = newURL
+	}
+	g.mu.Unlock()
 }
 
 // addEndpoint adds a new endpoint to an empty slot (nil or empty URL) in
@@ -3597,14 +3599,18 @@ func (g *GravityClient) stop() error {
 	g.handlerWg.Wait()
 
 	g.mu.Lock()
-	if g.connectionCancel != nil {
-		g.connectionCancel()
-	}
-	g.cancel()
-
-	g.cleanup()
+	connectionCancel := g.connectionCancel
+	cancel := g.cancel
 	g.connected = false
 	g.mu.Unlock()
+
+	if connectionCancel != nil {
+		connectionCancel()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	g.cleanup()
 
 	return nil
 }
@@ -4776,6 +4782,8 @@ func (g *GravityClient) reconnectWithTimeout(timeout time.Duration) error {
 // reconnect resets connection state and attempts to start a new connection
 func (g *GravityClient) reconnect() error {
 	g.logger.Debug("reconnect called")
+	g.stopPeerDiscovery()
+
 	// Reset connection state without holding lock during Start()
 	g.mu.Lock()
 	g.ensureConnectionContextLocked()
@@ -4783,12 +4791,6 @@ func (g *GravityClient) reconnect() error {
 	g.closing = false // Reset closing flag to allow reconnection
 	g.initialStartupDone.Store(false)
 	g.sessionReady = make(chan struct{})
-
-	if g.discoveryCancel != nil {
-		g.discoveryCancel()
-		g.discoveryCtx = nil
-		g.discoveryCancel = nil
-	}
 
 	// Clear connection IDs from previous connection
 	g.connectionIDs = make([]string, 0, g.poolConfig.PoolSize)
@@ -4901,13 +4903,7 @@ func (g *GravityClient) extractHostnameFromURL(inputURL string) (string, error) 
 
 func (g *GravityClient) cleanup() {
 	g.logger.Debug("cleanup called")
-
-	if g.discoveryCancel != nil {
-		g.discoveryCancel()
-		g.discoveryCtx = nil
-		g.discoveryCancel = nil
-	}
-	g.initialStartupDone.Store(false)
+	g.stopPeerDiscovery()
 
 	// Cancel all stream contexts
 	for _, cancel := range g.streamManager.cancels {
@@ -4921,6 +4917,42 @@ func (g *GravityClient) cleanup() {
 		if conn != nil {
 			conn.Close()
 		}
+	}
+}
+
+func (g *GravityClient) startPeerDiscovery() {
+	if g.discoveryResolveFunc == nil {
+		return
+	}
+
+	g.discoveryMu.Lock()
+	defer g.discoveryMu.Unlock()
+
+	ctx, cancel := context.WithCancel(g.ctx)
+	done := make(chan struct{})
+	g.discoveryCtx = ctx
+	g.discoveryCancel = cancel
+	g.discoveryDone = done
+
+	go g.peerDiscoveryLoop(ctx, done)
+}
+
+func (g *GravityClient) stopPeerDiscovery() {
+	g.initialStartupDone.Store(false)
+
+	g.discoveryMu.Lock()
+	cancel := g.discoveryCancel
+	done := g.discoveryDone
+	g.discoveryCtx = nil
+	g.discoveryCancel = nil
+	g.discoveryDone = nil
+	g.discoveryMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
 	}
 }
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -283,6 +283,7 @@ type GravityClient struct {
 	reconnectionFailedCallback func(attempts int, lastErr error)
 	onEndpointReady            func(endpointIndex int)
 	onEndpointTunnelReady      func(endpointIndex int)
+	reconnectEndpointHook      func(endpointIndex int, reason string) // test hook; nil in production
 
 	// State management
 	connected            bool
@@ -1673,8 +1674,15 @@ func (g *GravityClient) cycleEndpoint(oldURL, newURL string) {
 	g.endpoints[oldIdx] = newEp
 	g.endpointsMu.Unlock()
 
+	g.mu.Lock()
+	if oldIdx >= 0 && oldIdx < len(g.connectionURLs) {
+		g.connectionURLs[oldIdx] = newURL
+	}
+	g.mu.Unlock()
+
 	g.logger.Info("peer discovery: endpoint cycled: removed %s, added %s", oldURL, newURL)
-	g.logger.Debug("peer discovery: new endpoint %s will connect on next connection attempt", newURL)
+	g.disconnectEndpointStreams(oldIdx)
+	g.scheduleEndpointReconnect(oldIdx, "peer_discovery_cycle")
 }
 
 // addEndpoint adds a new endpoint to an empty slot (nil or empty URL) in
@@ -1767,7 +1775,23 @@ func (g *GravityClient) addEndpoint(newURL string) {
 	g.streamManager.healthMu.Unlock()
 
 	g.logger.Info("peer discovery: added new endpoint %s at slot %d, starting reconnection", newURL, slotIdx)
-	go g.reconnectEndpoint(slotIdx, "peer_discovery_add")
+	g.scheduleEndpointReconnect(slotIdx, "peer_discovery_add")
+}
+
+func (g *GravityClient) scheduleEndpointReconnect(endpointIndex int, reason string) {
+	if endpointIndex < 0 || endpointIndex >= len(g.endpointReconnecting) {
+		g.logger.Warn("invalid endpoint index %d for reconnect reason=%s", endpointIndex, reason)
+		return
+	}
+	if !g.endpointReconnecting[endpointIndex].CompareAndSwap(false, true) {
+		g.logger.Debug("endpoint %d already reconnecting, skipping scheduled reconnect: %s", endpointIndex, reason)
+		return
+	}
+	if g.reconnectEndpointHook != nil {
+		g.reconnectEndpointHook(endpointIndex, reason)
+		return
+	}
+	go g.reconnectEndpoint(endpointIndex, reason)
 }
 
 func pickRandomURL(urls []string) string {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -237,16 +237,17 @@ type GravityClient struct {
 	multiEndpointMode atomic.Bool // true when client is effectively in multi-endpoint mode
 
 	// Peer discovery and cycling
-	discoveryResolveFunc  func() []string
-	peerDiscoveryInterval time.Duration
-	peerCycleInterval     time.Duration
-	lastCycleTime         atomic.Int64  // unix timestamp of last cycle
-	peerDiscoveryWake     chan struct{} // non-blocking signal to wake the discovery loop immediately
-	discoveryCtx          context.Context
-	discoveryCancel       context.CancelFunc
-	discoveryDone         chan struct{}
-	discoveryMu           sync.Mutex
-	initialStartupDone    atomic.Bool
+	discoveryResolveFunc    func() []string
+	peerDiscoveryInterval   time.Duration
+	peerCycleInterval       time.Duration
+	lastCycleTime           atomic.Int64  // unix timestamp of last cycle
+	peerDiscoveryWake       chan struct{} // non-blocking signal to wake the discovery loop immediately
+	discoveryCtx            context.Context
+	discoveryCancel         context.CancelFunc
+	discoveryDone           chan struct{}
+	discoveryMu             sync.Mutex
+	discoveryResolveTimeout time.Duration
+	initialStartupDone      atomic.Bool
 
 	// dnsLookupMulti is the function used to resolve hostnames during
 	// endpoint re-resolution. Defaults to dns.DefaultDNS.LookupMulti.
@@ -401,6 +402,7 @@ type StreamInfo struct {
 }
 
 const endpointDiscoveryRefreshFailureThreshold int32 = 10
+const defaultPeerDiscoveryResolveTimeout = 5 * time.Second
 
 // StreamManager manages multiple gRPC streams for multiplexing with advanced load balancing
 type StreamManager struct {
@@ -1531,7 +1533,10 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 		return
 	}
 
-	allURLs := g.discoveryResolveFunc()
+	allURLs, ok := g.resolvePeerDiscoveryURLs()
+	if !ok {
+		return
+	}
 	if len(allURLs) == 0 {
 		g.logger.Debug("peer discovery: resolve returned no URLs")
 		return
@@ -4953,6 +4958,42 @@ func (g *GravityClient) stopPeerDiscovery() {
 	}
 	if done != nil {
 		<-done
+	}
+}
+
+func (g *GravityClient) resolvePeerDiscoveryURLs() ([]string, bool) {
+	g.discoveryMu.Lock()
+	ctx := g.discoveryCtx
+	timeout := g.discoveryResolveTimeout
+	g.discoveryMu.Unlock()
+
+	if ctx == nil {
+		ctx = g.ctx
+	}
+	if timeout <= 0 {
+		timeout = defaultPeerDiscoveryResolveTimeout
+	}
+
+	resultCh := make(chan []string, 1)
+	go func() {
+		urls := g.discoveryResolveFunc()
+		select {
+		case resultCh <- urls:
+		case <-ctx.Done():
+		}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return nil, false
+	case urls := <-resultCh:
+		return urls, true
+	case <-timer.C:
+		g.logger.Warn("peer discovery: resolver timed out after %s", timeout)
+		return nil, false
 	}
 }
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -242,6 +242,8 @@ type GravityClient struct {
 	peerCycleInterval     time.Duration
 	lastCycleTime         atomic.Int64  // unix timestamp of last cycle
 	peerDiscoveryWake     chan struct{} // non-blocking signal to wake the discovery loop immediately
+	discoveryCtx          context.Context
+	discoveryCancel       context.CancelFunc
 
 	// dnsLookupMulti is the function used to resolve hostnames during
 	// endpoint re-resolution. Defaults to dns.DefaultDNS.LookupMulti.
@@ -932,8 +934,14 @@ func (g *GravityClient) startMultiEndpoint() error {
 	// Start peer discovery only after per-endpoint reconnect state is sized.
 	// peerDiscoveryLoop can schedule reconnects immediately via addEndpoint()
 	// and cycleEndpoint(), so the reconnect guard slices must already exist.
+	if g.discoveryCancel != nil {
+		g.discoveryCancel()
+		g.discoveryCtx = nil
+		g.discoveryCancel = nil
+	}
 	if g.discoveryResolveFunc != nil {
-		go g.peerDiscoveryLoop()
+		g.discoveryCtx, g.discoveryCancel = context.WithCancel(g.ctx)
+		go g.peerDiscoveryLoop(g.discoveryCtx)
 	}
 
 	g.logger.Debug("establishing %d gRPC connections", connectionCount)
@@ -1431,7 +1439,7 @@ func (g *GravityClient) bindingCleanupLoop() {
 	}
 }
 
-func (g *GravityClient) peerDiscoveryLoop() {
+func (g *GravityClient) peerDiscoveryLoop(ctx context.Context) {
 	idleInterval := g.peerDiscoveryInterval
 	if idleInterval <= 0 {
 		idleInterval = DefaultPeerDiscoveryInterval
@@ -1475,7 +1483,7 @@ func (g *GravityClient) peerDiscoveryLoop() {
 
 	for {
 		select {
-		case <-g.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-g.peerDiscoveryWake:
 			// Woken by an endpoint going unhealthy — re-check immediately.
@@ -1790,6 +1798,7 @@ func (g *GravityClient) scheduleEndpointReconnect(endpointIndex int, reason stri
 		return
 	}
 	if g.reconnectEndpointHook != nil {
+		defer g.endpointReconnecting[endpointIndex].Store(false)
 		g.reconnectEndpointHook(endpointIndex, reason)
 		return
 	}
@@ -4873,6 +4882,12 @@ func (g *GravityClient) extractHostnameFromURL(inputURL string) (string, error) 
 
 func (g *GravityClient) cleanup() {
 	g.logger.Debug("cleanup called")
+
+	if g.discoveryCancel != nil {
+		g.discoveryCancel()
+		g.discoveryCtx = nil
+		g.discoveryCancel = nil
+	}
 
 	// Cancel all stream contexts
 	for _, cancel := range g.streamManager.cancels {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -888,11 +888,6 @@ func (g *GravityClient) startMultiEndpoint() error {
 		go g.bindingCleanupLoop()
 	})
 
-	// Start peer discovery and connection cycling when a resolver is configured.
-	if g.discoveryResolveFunc != nil {
-		go g.peerDiscoveryLoop()
-	}
-
 	g.logger.Debug("loading CA certificate for TLS...")
 	pool, err := x509.SystemCertPool()
 	if err != nil {
@@ -932,6 +927,13 @@ func (g *GravityClient) startMultiEndpoint() error {
 	g.streamManager.connectionIdleCount = make([]int, connectionCount)
 	for i := range g.streamManager.connectionHealth {
 		g.streamManager.connectionHealth[i] = true
+	}
+
+	// Start peer discovery only after per-endpoint reconnect state is sized.
+	// peerDiscoveryLoop can schedule reconnects immediately via addEndpoint()
+	// and cycleEndpoint(), so the reconnect guard slices must already exist.
+	if g.discoveryResolveFunc != nil {
+		go g.peerDiscoveryLoop()
 	}
 
 	g.logger.Debug("establishing %d gRPC connections", connectionCount)

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -670,3 +670,78 @@ func TestCycleEndpoint_TriggersReconnectForReplacementSlot(t *testing.T) {
 		t.Fatalf("expected connection URL for replacement slot to be updated, got %q", g.connectionURLs[1])
 	}
 }
+
+func TestScheduleEndpointReconnect_HookClearsReconnectGuard(t *testing.T) {
+	g := newTestGravityClient(nil, []string{"grpc://g1.example.com"})
+	defer g.cancel()
+
+	var calls int
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		calls++
+	}
+
+	g.scheduleEndpointReconnect(0, "first")
+	if calls != 1 {
+		t.Fatalf("expected first reconnect hook call, got %d", calls)
+	}
+	if g.endpointReconnecting[0].Load() {
+		t.Fatal("expected reconnect guard to be cleared after hook returns")
+	}
+
+	g.scheduleEndpointReconnect(0, "second")
+	if calls != 2 {
+		t.Fatalf("expected second reconnect hook call after guard reset, got %d", calls)
+	}
+}
+
+func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
+	g := newTestGravityClient([]string{
+		"grpc://g1.example.com",
+		"grpc://g2.example.com",
+	}, []string{
+		"grpc://g1.example.com",
+	})
+	defer g.cancel()
+
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://g1.example.com",
+			"grpc://g2.example.com",
+		}
+	}
+
+	called := make(chan struct{}, 1)
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		called <- struct{}{}
+	}
+
+	discoveryCtx, discoveryCancel := context.WithCancel(context.Background())
+	g.discoveryCtx, g.discoveryCancel = discoveryCtx, discoveryCancel
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		g.peerDiscoveryLoop(discoveryCtx)
+	}()
+
+	g.cleanup()
+
+	select {
+	case <-discoveryCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected cleanup to cancel peer discovery context")
+	}
+
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("expected peer discovery loop to exit after cleanup canceled its context")
+	}
+
+	g.wakePeerDiscovery()
+	select {
+	case <-called:
+		t.Fatal("expected canceled peer discovery loop to stop scheduling reconnects")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -3,6 +3,8 @@ package gravity
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,19 +16,35 @@ import (
 func newTestGravityClient(urls []string, connected []string) *GravityClient {
 	ctx, cancel := context.WithCancel(context.Background())
 	g := &GravityClient{
-		ctx:    ctx,
-		cancel: cancel,
-		logger: logger.NewTestLogger(),
+		context: ctx,
+		ctx:     ctx,
+		cancel:  cancel,
+		logger:  logger.NewTestLogger(),
 		poolConfig: ConnectionPoolConfig{
 			MaxGravityPeers: 3,
 		},
+		streamManager: &StreamManager{},
 	}
 	g.gravityURLs = append([]string(nil), urls...)
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		if idx >= 0 && idx < len(g.endpointReconnecting) {
+			g.endpointReconnecting[idx].Store(false)
+		}
+	}
 
 	for _, u := range connected {
 		ep := &GravityEndpoint{URL: u}
 		ep.healthy.Store(true)
 		g.endpoints = append(g.endpoints, ep)
+		g.connectionURLs = append(g.connectionURLs, u)
+		g.endpointReconnecting = append(g.endpointReconnecting, atomic.Bool{})
+		g.endpointFailCount = append(g.endpointFailCount, atomic.Int32{})
+		g.streamManager.controlStreams = append(g.streamManager.controlStreams, nil)
+		g.streamManager.controlSendMu = append(g.streamManager.controlSendMu, sync.Mutex{})
+		g.streamManager.contexts = append(g.streamManager.contexts, nil)
+		g.streamManager.cancels = append(g.streamManager.cancels, nil)
+		g.streamManager.connectionHealth = append(g.streamManager.connectionHealth, true)
+		g.streamManager.connectionIdleCount = append(g.streamManager.connectionIdleCount, 0)
 	}
 
 	return g
@@ -611,5 +629,44 @@ func TestCycleEndpoint_PreservesSliceOrder(t *testing.T) {
 		if ep.URL != expected[i] {
 			t.Errorf("endpoint[%d]: expected %s, got %s", i, expected[i], ep.URL)
 		}
+	}
+}
+
+func TestCycleEndpoint_TriggersReconnectForReplacementSlot(t *testing.T) {
+	g := newTestGravityClient(nil, []string{
+		"grpc://g1.example.com",
+		"grpc://g2.example.com",
+		"grpc://g3.example.com",
+	})
+	defer g.cancel()
+
+	called := make(chan struct{}, 1)
+	var gotIdx int
+	var gotReason string
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		gotIdx = idx
+		gotReason = reason
+		called <- struct{}{}
+	}
+
+	g.cycleEndpoint("grpc://g2.example.com", "grpc://g4.example.com")
+
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("expected replacement endpoint reconnect to be scheduled")
+	}
+
+	if gotIdx != 1 {
+		t.Fatalf("expected reconnect for slot 1, got %d", gotIdx)
+	}
+	if gotReason != "peer_discovery_cycle" {
+		t.Fatalf("expected peer_discovery_cycle reason, got %q", gotReason)
+	}
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if g.connectionURLs[1] != "grpc://g4.example.com" {
+		t.Fatalf("expected connection URL for replacement slot to be updated, got %q", g.connectionURLs[1])
 	}
 }

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -25,6 +25,7 @@ func newTestGravityClient(urls []string, connected []string) *GravityClient {
 		},
 		streamManager: &StreamManager{},
 	}
+	g.initialStartupDone.Store(true)
 	g.gravityURLs = append([]string(nil), urls...)
 	g.reconnectEndpointHook = func(idx int, reason string) {
 		if idx >= 0 && idx < len(g.endpointReconnecting) {
@@ -640,12 +641,47 @@ func TestCycleEndpoint_TriggersReconnectForReplacementSlot(t *testing.T) {
 	})
 	defer g.cancel()
 
+	ctx := context.Background()
+	g.streamManager.controlMu.Lock()
+	g.streamManager.controlStreams[1] = &mockControlStream{ctx: ctx}
+	g.streamManager.controlMu.Unlock()
+	g.streamManager.tunnelMu.Lock()
+	g.streamManager.tunnelStreams = []*StreamInfo{
+		{
+			stream:    &mockTunnelStream{ctx: ctx},
+			connIndex: 1,
+			isHealthy: true,
+		},
+	}
+	g.streamManager.tunnelMu.Unlock()
+
 	called := make(chan struct{}, 1)
 	var gotIdx int
 	var gotReason string
 	g.reconnectEndpointHook = func(idx int, reason string) {
 		gotIdx = idx
 		gotReason = reason
+
+		g.streamManager.controlMu.RLock()
+		controlCleared := idx < len(g.streamManager.controlStreams) && g.streamManager.controlStreams[idx] == nil
+		g.streamManager.controlMu.RUnlock()
+		if !controlCleared {
+			t.Errorf("expected control stream for slot %d to be cleared before reconnect scheduling", idx)
+		}
+
+		g.streamManager.tunnelMu.RLock()
+		tunnelCleared := false
+		for _, si := range g.streamManager.tunnelStreams {
+			if si != nil && si.connIndex == idx {
+				tunnelCleared = !si.isHealthy
+				break
+			}
+		}
+		g.streamManager.tunnelMu.RUnlock()
+		if !tunnelCleared {
+			t.Errorf("expected tunnel stream for slot %d to be marked unhealthy before reconnect scheduling", idx)
+		}
+
 		called <- struct{}{}
 	}
 
@@ -668,6 +704,37 @@ func TestCycleEndpoint_TriggersReconnectForReplacementSlot(t *testing.T) {
 	defer g.mu.RUnlock()
 	if g.connectionURLs[1] != "grpc://g4.example.com" {
 		t.Fatalf("expected connection URL for replacement slot to be updated, got %q", g.connectionURLs[1])
+	}
+}
+
+func TestCheckPeerDiscovery_SkipsBeforeInitialStartupDone(t *testing.T) {
+	g := newTestGravityClient([]string{
+		"grpc://g1.example.com",
+		"grpc://g2.example.com",
+	}, []string{
+		"grpc://g1.example.com",
+	})
+	defer g.cancel()
+
+	g.initialStartupDone.Store(false)
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://g1.example.com",
+			"grpc://g2.example.com",
+		}
+	}
+
+	called := make(chan struct{}, 1)
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		called <- struct{}{}
+	}
+
+	g.checkPeerDiscovery(2 * time.Hour)
+
+	select {
+	case <-called:
+		t.Fatal("expected peer discovery to remain idle before initial startup completes")
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -662,6 +662,13 @@ func TestCycleEndpoint_TriggersReconnectForReplacementSlot(t *testing.T) {
 		gotIdx = idx
 		gotReason = reason
 
+		g.mu.RLock()
+		urlCleared := idx < len(g.connectionURLs) && g.connectionURLs[idx] == ""
+		g.mu.RUnlock()
+		if !urlCleared {
+			t.Errorf("expected connection URL for slot %d to be cleared before reconnect scheduling", idx)
+		}
+
 		g.streamManager.controlMu.RLock()
 		controlCleared := idx < len(g.streamManager.controlStreams) && g.streamManager.controlStreams[idx] == nil
 		g.streamManager.controlMu.RUnlock()
@@ -783,13 +790,12 @@ func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
 		called <- struct{}{}
 	}
 
-	discoveryCtx, discoveryCancel := context.WithCancel(context.Background())
-	g.discoveryCtx, g.discoveryCancel = discoveryCtx, discoveryCancel
-	loopDone := make(chan struct{})
-	go func() {
-		defer close(loopDone)
-		g.peerDiscoveryLoop(discoveryCtx)
-	}()
+	g.startPeerDiscovery()
+
+	g.discoveryMu.Lock()
+	discoveryCtx := g.discoveryCtx
+	discoveryDone := g.discoveryDone
+	g.discoveryMu.Unlock()
 
 	g.cleanup()
 
@@ -800,7 +806,7 @@ func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
 	}
 
 	select {
-	case <-loopDone:
+	case <-discoveryDone:
 	case <-time.After(time.Second):
 		t.Fatal("expected peer discovery loop to exit after cleanup canceled its context")
 	}
@@ -810,5 +816,60 @@ func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
 	case <-called:
 		t.Fatal("expected canceled peer discovery loop to stop scheduling reconnects")
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestCleanup_WaitsForInFlightPeerDiscoveryCheck(t *testing.T) {
+	g := newTestGravityClient([]string{
+		"grpc://g1.example.com",
+		"grpc://g2.example.com",
+	}, []string{
+		"grpc://g1.example.com",
+	})
+	defer g.cancel()
+
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	g.discoveryResolveFunc = func() []string {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		return []string{
+			"grpc://g1.example.com",
+			"grpc://g2.example.com",
+		}
+	}
+
+	g.startPeerDiscovery()
+	g.wakePeerDiscovery()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("expected peer discovery check to start")
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		g.cleanup()
+	}()
+
+	select {
+	case <-cleanupDone:
+		t.Fatal("expected cleanup to wait for in-flight peer discovery check")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("expected cleanup to return after peer discovery check completed")
 	}
 }

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -819,7 +819,7 @@ func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
 	}
 }
 
-func TestCleanup_WaitsForInFlightPeerDiscoveryCheck(t *testing.T) {
+func TestCleanup_CancelsBlockedPeerDiscoveryResolve(t *testing.T) {
 	g := newTestGravityClient([]string{
 		"grpc://g1.example.com",
 		"grpc://g2.example.com",
@@ -831,6 +831,7 @@ func TestCleanup_WaitsForInFlightPeerDiscoveryCheck(t *testing.T) {
 	g.peerDiscoveryWake = make(chan struct{}, 1)
 	started := make(chan struct{})
 	release := make(chan struct{})
+	g.discoveryResolveTimeout = 50 * time.Millisecond
 	g.discoveryResolveFunc = func() []string {
 		select {
 		case <-started:
@@ -861,15 +862,9 @@ func TestCleanup_WaitsForInFlightPeerDiscoveryCheck(t *testing.T) {
 
 	select {
 	case <-cleanupDone:
-		t.Fatal("expected cleanup to wait for in-flight peer discovery check")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
+		t.Fatal("expected cleanup to return promptly after canceling blocked peer discovery resolve")
 	}
 
 	close(release)
-
-	select {
-	case <-cleanupDone:
-	case <-time.After(time.Second):
-		t.Fatal("expected cleanup to return after peer discovery check completed")
-	}
 }


### PR DESCRIPTION
## Summary
- reconnect replacement endpoints immediately when peer discovery cycles a stale Gravity endpoint URL
- clear old slot connection/stream state before reconnecting the replacement endpoint
- add focused peer-discovery regression coverage for the replacement slot path

## Validation
- go test ./gravity -run 'TestCycleEndpoint_|TestMaybeCyclePeerDiscoveryConnections_'
- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating endpoint rotation, reconnect scheduling, gated peer discovery during initial startup, and that discovery stops cleanly during cleanup.

* **Chores**
  * Strengthened peer-discovery and reconnection lifecycle and concurrency guards so endpoint rotation clears stale state, reconnections are scheduled deterministically, discovery is deferred until initial startup completes, and discovery is canceled during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->