### PR TITLE
Fix Gravity session hello failure handling

### DIFF
--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -213,7 +213,7 @@ func TestEstablishControlStreams_SingleEndpointPreservesOriginalBehavior(t *test
 func TestEstablishTunnelStreams_SkipsNilClients(t *testing.T) {
 	g := newResilienceTestClient(t, 4, true)
 	g.poolConfig.StreamsPerGravity = 2
-	g.connectionIDChan = make(chan string)
+	g.connectionIDChan = make(chan sessionHelloSignal)
 
 	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
 		&mockControlStream{ctx: g.ctx},
@@ -237,8 +237,8 @@ func TestEstablishTunnelStreams_SkipsNilClients(t *testing.T) {
 
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		g.connectionIDChan <- "machine-1"
-		g.connectionIDChan <- "machine-1"
+		g.connectionIDChan <- sessionHelloSignal{streamIndex: 0, machineID: "machine-1"}
+		g.connectionIDChan <- sessionHelloSignal{streamIndex: 2, machineID: "machine-1"}
 	}()
 
 	err := g.establishTunnelStreams()
@@ -284,8 +284,8 @@ func TestEstablishTunnelStreams_SkipsNilClients(t *testing.T) {
 func TestEstablishTunnelStreams_UsesAlreadyReceivedMachineID(t *testing.T) {
 	g := newResilienceTestClient(t, 1, false)
 	g.poolConfig.StreamsPerConnection = 1
-	g.connectionIDChan = make(chan string, 1)
-	g.connectionIDChan <- "machine-1"
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 0, machineID: "machine-1"}
 	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
 		&mockControlStream{ctx: g.ctx},
 	}
@@ -301,9 +301,30 @@ func TestEstablishTunnelStreams_UsesAlreadyReceivedMachineID(t *testing.T) {
 	}
 }
 
+func TestEstablishTunnelStreams_IgnoresFailureForUnexpectedStream(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.poolConfig.StreamsPerConnection = 1
+	g.connectionIDChan = make(chan sessionHelloSignal, 2)
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 1}
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 0, machineID: "machine-1"}
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&mockControlStream{ctx: g.ctx},
+	}
+	client := &mockSessionClient{}
+	g.sessionClients = []pb.GravitySessionServiceClient{client}
+	g.helloAckedStreams.Store(0, true)
+
+	if err := g.establishTunnelStreams(); err != nil {
+		t.Fatalf("expected unrelated stream failure to be ignored, got error: %v", err)
+	}
+	if client.streamPacketsCalls != 1 {
+		t.Fatalf("expected StreamSessionPackets calls=1, got %d", client.streamPacketsCalls)
+	}
+}
+
 func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
 	g := newResilienceTestClient(t, 1, false)
-	g.connectionIDChan = make(chan string, 1)
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
 	stream := &configurableMockStream{
 		recvErr: status.Error(codes.Unauthenticated, "no organization registered with this public key"),
 	}
@@ -315,9 +336,9 @@ func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
 	}()
 
 	select {
-	case id := <-g.connectionIDChan:
-		if id != "" {
-			t.Fatalf("expected empty failure signal, got %q", id)
+	case sig := <-g.connectionIDChan:
+		if sig.streamIndex != 0 || sig.machineID != "" {
+			t.Fatalf("expected failure signal for stream 0, got %+v", sig)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected pre-hello receive error to signal startup failure")
@@ -327,5 +348,32 @@ func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("expected control stream handler to exit")
+	}
+}
+
+func TestSendSessionHelloSignal_RoutesToEndpointChannel(t *testing.T) {
+	g := newResilienceTestClient(t, 2, true)
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
+	helloCh := make(chan sessionHelloSignal, 1)
+	g.sessionHelloChans.Store(1, helloCh)
+	defer g.sessionHelloChans.Delete(1)
+
+	if ok := g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: 1, machineID: "machine-1"}); !ok {
+		t.Fatal("expected signal send to succeed")
+	}
+
+	select {
+	case sig := <-helloCh:
+		if sig.streamIndex != 1 || sig.machineID != "machine-1" {
+			t.Fatalf("unexpected endpoint signal: %+v", sig)
+		}
+	default:
+		t.Fatal("expected signal on endpoint channel")
+	}
+
+	select {
+	case sig := <-g.connectionIDChan:
+		t.Fatalf("did not expect signal on shared channel: %+v", sig)
+	default:
 	}
 }

--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -3,6 +3,7 @@ package gravity
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -322,6 +323,28 @@ func TestEstablishTunnelStreams_IgnoresFailureForUnexpectedStream(t *testing.T) 
 	}
 }
 
+func TestEstablishTunnelStreams_ReturnsSessionHelloFailureMessage(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.poolConfig.StreamsPerConnection = 1
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
+	g.connectionIDChan <- sessionHelloSignal{
+		streamIndex: 0,
+		errMessage:  "no organization registered with this public key",
+	}
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&mockControlStream{ctx: g.ctx},
+	}
+	g.sessionClients = []pb.GravitySessionServiceClient{&mockSessionClient{}}
+
+	err := g.establishTunnelStreams()
+	if err == nil {
+		t.Fatal("expected session hello failure")
+	}
+	if !strings.Contains(err.Error(), "no organization registered with this public key") {
+		t.Fatalf("expected concrete rejection message, got: %v", err)
+	}
+}
+
 func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
 	g := newResilienceTestClient(t, 1, false)
 	g.connectionIDChan = make(chan sessionHelloSignal, 1)
@@ -339,6 +362,9 @@ func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
 	case sig := <-g.connectionIDChan:
 		if sig.streamIndex != 0 || sig.machineID != "" {
 			t.Fatalf("expected failure signal for stream 0, got %+v", sig)
+		}
+		if sig.errMessage != "no organization registered with this public key" {
+			t.Fatalf("expected gRPC status message, got %q", sig.errMessage)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected pre-hello receive error to signal startup failure")
@@ -375,5 +401,39 @@ func TestSendSessionHelloSignal_RoutesToEndpointChannel(t *testing.T) {
 	case sig := <-g.connectionIDChan:
 		t.Fatalf("did not expect signal on shared channel: %+v", sig)
 	default:
+	}
+}
+
+func TestHandleGenericResponse_SessionHelloFailureIncludesError(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
+
+	g.handleGenericResponse(0, "session_hello", &pb.ProtocolResponse{
+		Success: false,
+		Error:   "certificate rejected",
+	})
+
+	select {
+	case sig := <-g.connectionIDChan:
+		if sig.streamIndex != 0 || sig.machineID != "" {
+			t.Fatalf("expected failure signal for stream 0, got %+v", sig)
+		}
+		if sig.errMessage != "certificate rejected" {
+			t.Fatalf("expected protocol response error, got %q", sig.errMessage)
+		}
+	default:
+		t.Fatal("expected session hello failure signal")
+	}
+}
+
+func TestSessionHelloChannelCapacityScalesWithPoolSizeForSingleURL(t *testing.T) {
+	if got := sessionHelloChannelCapacity(4, 1); got != 4 {
+		t.Fatalf("expected capacity 4 for pool size 4 and one URL, got %d", got)
+	}
+	if got := sessionHelloChannelCapacity(4, 0); got != 4 {
+		t.Fatalf("expected capacity 4 for pool size 4 and no GravityURLs, got %d", got)
+	}
+	if got := sessionHelloChannelCapacity(4, 3); got != 12 {
+		t.Fatalf("expected capacity 12 for pool size 4 and three URLs, got %d", got)
 	}
 }

--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -280,3 +280,52 @@ func TestEstablishTunnelStreams_SkipsNilClients(t *testing.T) {
 		}
 	}
 }
+
+func TestEstablishTunnelStreams_UsesAlreadyReceivedMachineID(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.poolConfig.StreamsPerConnection = 1
+	g.connectionIDChan = make(chan string, 1)
+	g.connectionIDChan <- "machine-1"
+	g.streamManager.controlStreams = []pb.GravitySessionService_EstablishSessionClient{
+		&mockControlStream{ctx: g.ctx},
+	}
+	client := &mockSessionClient{}
+	g.sessionClients = []pb.GravitySessionServiceClient{client}
+	g.helloAckedStreams.Store(0, true)
+
+	if err := g.establishTunnelStreams(); err != nil {
+		t.Fatalf("expected already received machine ID to be used, got error: %v", err)
+	}
+	if client.streamPacketsCalls != 1 {
+		t.Fatalf("expected StreamSessionPackets calls=1, got %d", client.streamPacketsCalls)
+	}
+}
+
+func TestHandleControlStream_PreHelloReceiveErrorSignalsFailure(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.connectionIDChan = make(chan string, 1)
+	stream := &configurableMockStream{
+		recvErr: status.Error(codes.Unauthenticated, "no organization registered with this public key"),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handleControlStream(0, stream)
+	}()
+
+	select {
+	case id := <-g.connectionIDChan:
+		if id != "" {
+			t.Fatalf("expected empty failure signal, got %q", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected pre-hello receive error to signal startup failure")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected control stream handler to exit")
+	}
+}

--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -76,7 +76,7 @@ func newEndpointTestClient(t *testing.T, n int) *GravityClient {
 		endpoints:             make([]*GravityEndpoint, n),
 		endpointReconnecting:  make([]atomic.Bool, n),
 		circuitBreakers:       make([]*CircuitBreaker, n),
-		connectionIDChan:      make(chan string, 16),
+		connectionIDChan:      make(chan sessionHelloSignal, 16),
 		endpointStreamIndices: make(map[string][]int),
 		closed:                make(chan struct{}, 1),
 		streamManager: &StreamManager{
@@ -490,9 +490,9 @@ func TestHandleEndpointDisconnection_ConcurrentPerEndpoint(t *testing.T) {
 
 func TestDrainConnectionIDChan_DrainsAllValues(t *testing.T) {
 	g := newEndpointTestClient(t, 1)
-	g.connectionIDChan = make(chan string, 8)
+	g.connectionIDChan = make(chan sessionHelloSignal, 8)
 	for i := 0; i < 5; i++ {
-		g.connectionIDChan <- fmt.Sprintf("id-%d", i)
+		g.connectionIDChan <- sessionHelloSignal{streamIndex: i, machineID: fmt.Sprintf("id-%d", i)}
 	}
 
 	g.drainConnectionIDChan()
@@ -504,7 +504,7 @@ func TestDrainConnectionIDChan_DrainsAllValues(t *testing.T) {
 
 func TestDrainConnectionIDChan_EmptyNoOp(t *testing.T) {
 	g := newEndpointTestClient(t, 1)
-	g.connectionIDChan = make(chan string, 1)
+	g.connectionIDChan = make(chan sessionHelloSignal, 1)
 
 	done := make(chan struct{})
 	go func() {
@@ -981,7 +981,7 @@ func TestTriggerAllEndpointReconnections_AllUnhealthy_ReconnectsAll(t *testing.T
 		endpoints:             make([]*GravityEndpoint, 3),
 		endpointReconnecting:  make([]atomic.Bool, 3),
 		circuitBreakers:       make([]*CircuitBreaker, 3),
-		connectionIDChan:      make(chan string, 16),
+		connectionIDChan:      make(chan sessionHelloSignal, 16),
 		endpointStreamIndices: make(map[string][]int),
 		closed:                make(chan struct{}, 1),
 		streamManager: &StreamManager{
@@ -1834,7 +1834,7 @@ func TestTriggerAllEndpointReconnections_ConcurrentCalls(t *testing.T) {
 		endpoints:             make([]*GravityEndpoint, 3),
 		endpointReconnecting:  make([]atomic.Bool, 3),
 		circuitBreakers:       make([]*CircuitBreaker, 3),
-		connectionIDChan:      make(chan string, 16),
+		connectionIDChan:      make(chan sessionHelloSignal, 16),
 		endpointStreamIndices: make(map[string][]int),
 		closed:                make(chan struct{}, 1),
 		peerDiscoveryWake:     make(chan struct{}, 1),
@@ -1908,7 +1908,7 @@ func TestTriggerAllEndpointReconnections_SingleEndpointMode(t *testing.T) {
 		endpoints:             make([]*GravityEndpoint, 1),
 		endpointReconnecting:  make([]atomic.Bool, 1),
 		circuitBreakers:       make([]*CircuitBreaker, 1),
-		connectionIDChan:      make(chan string, 16),
+		connectionIDChan:      make(chan sessionHelloSignal, 16),
 		endpointStreamIndices: make(map[string][]int),
 		closed:                make(chan struct{}, 1),
 		peerDiscoveryWake:     make(chan struct{}, 1),

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -394,6 +394,30 @@ type GravityClient struct {
 type sessionHelloSignal struct {
 	streamIndex int
 	machineID   string
+	errMessage  string
+}
+
+func sessionHelloChannelCapacity(poolSize, gravityURLCount int) int {
+	return max(1, poolSize) * max(1, gravityURLCount)
+}
+
+func firstSessionHelloFailureMessage(messages map[int]string) string {
+	for _, msg := range messages {
+		if msg != "" {
+			return msg
+		}
+	}
+	return "unknown session hello failure"
+}
+
+func sessionHelloErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if st, ok := status.FromError(err); ok && st.Message() != "" {
+		return st.Message()
+	}
+	return err.Error()
 }
 
 // StreamInfo tracks individual stream health and load
@@ -516,7 +540,7 @@ func New(config GravityConfig) (*GravityClient, error) {
 		caCert:                 config.CACert,
 		defaultServerName:      config.DefaultServerName,
 		connectionIDs:          make([]string, 0, poolConfig.PoolSize),
-		connectionIDChan:       make(chan sessionHelloSignal, max(1, poolConfig.PoolSize*len(config.GravityURLs))),
+		connectionIDChan:       make(chan sessionHelloSignal, sessionHelloChannelCapacity(poolConfig.PoolSize, len(config.GravityURLs))),
 		sessionReady:           make(chan struct{}),
 		response:               make(chan *pb.ProtocolResponse, 100),
 		pending:                make(map[string]chan *pb.ProtocolResponse),
@@ -2139,6 +2163,7 @@ func (g *GravityClient) establishTunnelStreams() error {
 	var machineID string
 	helloResponseCount := 0
 	failedResponses := make(map[int]bool)
+	failureMessages := make(map[int]string)
 	successResponses := make(map[int]bool)
 	deadline := time.NewTimer(time.Minute)
 	defer deadline.Stop()
@@ -2151,10 +2176,15 @@ func (g *GravityClient) establishTunnelStreams() error {
 			}
 			if sig.machineID == "" {
 				failedResponses[sig.streamIndex] = true
-				g.logger.Error("session hello rejected by server on stream %d (%d/%d failures)", sig.streamIndex, len(failedResponses), len(expectedStreams))
+				failureMessages[sig.streamIndex] = sig.errMessage
+				if sig.errMessage != "" {
+					g.logger.Error("session hello rejected by server on stream %d (%d/%d failures): %s", sig.streamIndex, len(failedResponses), len(expectedStreams), sig.errMessage)
+				} else {
+					g.logger.Error("session hello rejected by server on stream %d (%d/%d failures)", sig.streamIndex, len(failedResponses), len(expectedStreams))
+				}
 				if len(failedResponses) == len(expectedStreams) && helloResponseCount == 0 {
 					g.logger.Error("session failed - authentication rejected by all expected servers")
-					return fmt.Errorf("session failed - authentication rejected by server")
+					return fmt.Errorf("session failed - authentication rejected by server: %s", firstSessionHelloFailureMessage(failureMessages))
 				}
 				continue
 			}
@@ -2179,7 +2209,7 @@ func (g *GravityClient) establishTunnelStreams() error {
 			}
 			if len(failedResponses) > 0 {
 				g.logger.Error("session failed - authentication rejected by %d/%d expected servers", len(failedResponses), len(expectedStreams))
-				return fmt.Errorf("session failed - authentication rejected by server")
+				return fmt.Errorf("session failed - authentication rejected by server: %s", firstSessionHelloFailureMessage(failureMessages))
 			}
 			g.logger.Error("timeout waiting for machine ID from server - possible server issue or network problem")
 			return fmt.Errorf("timeout waiting for machine ID from server")
@@ -2509,7 +2539,7 @@ func (g *GravityClient) logControlStreamReceiveError(streamIndex int, err error)
 
 func (g *GravityClient) signalSessionHelloFailure(streamIndex int, err error) {
 	g.logger.Error("control stream %d closed before session hello response; signaling startup failure: %s", streamIndex, err.Error())
-	g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex})
+	g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, errMessage: sessionHelloErrorMessage(err)})
 }
 
 func (g *GravityClient) sendSessionHelloSignal(sig sessionHelloSignal) bool {
@@ -2869,7 +2899,7 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	if g.machineSubnet != "" {
 		if _, _, err := net.ParseCIDR(g.machineSubnet); err != nil {
 			g.logger.Error("session hello returned invalid MachineSubnet %q: %v", g.machineSubnet, err)
-			signalConnectionID("")
+			g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, errMessage: fmt.Sprintf("invalid MachineSubnet %q: %s", g.machineSubnet, err.Error())})
 			closeSessionReady()
 			return
 		}
@@ -2899,7 +2929,7 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 		SigningPublicKey:  g.signingPublicKey,
 	}); err != nil {
 		g.logger.Error("error configuring provider after session hello: %v", err)
-		signalConnectionID("")
+		g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, errMessage: fmt.Sprintf("provider configuration failed: %s", err.Error())})
 		closeSessionReady()
 		return
 	}
@@ -2909,7 +2939,7 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	if g.networkInterface != nil {
 		if err := g.networkInterface.RouteTraffic(g.subnetRoutes); err != nil {
 			g.logger.Error("failed to route traffic for gravity subnet: %v", err)
-			signalConnectionID("")
+			g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, errMessage: fmt.Sprintf("route traffic failed: %s", err.Error())})
 			closeSessionReady()
 			return
 		}
@@ -3034,7 +3064,7 @@ func (g *GravityClient) handleGenericResponse(streamIndex int, msgID string, res
 	// Check if this is an error response for a session hello message
 	if msgID == "session_hello" && !response.Success {
 		g.logger.Error("session hello failed: %s", response.Error)
-		if !g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex}) {
+		if !g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, errMessage: response.Error}) {
 			g.logger.Warn("session hello failure signal dropped for stream %d", streamIndex)
 		}
 		return
@@ -4564,6 +4594,7 @@ func (g *GravityClient) reconnectSingleEndpoint(endpointIndex int, endpointURL s
 	helloCh := make(chan sessionHelloSignal, 1)
 	g.sessionHelloChans.Store(endpointIndex, helloCh)
 	defer g.sessionHelloChans.Delete(endpointIndex)
+	g.helloAckedStreams.Delete(endpointIndex)
 
 	go g.handleControlStream(endpointIndex, stream)
 
@@ -4582,6 +4613,9 @@ func (g *GravityClient) reconnectSingleEndpoint(endpointIndex int, endpointURL s
 			if sig.machineID == "" {
 				cancel()
 				_ = conn.Close()
+				if sig.errMessage != "" {
+					return fmt.Errorf("session hello rejected by server: %s", sig.errMessage)
+				}
 				return fmt.Errorf("session hello rejected by server")
 			}
 			g.logger.Debug("endpoint %d session hello accepted (machine ID: %s)", endpointIndex, sig.machineID)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -723,6 +723,12 @@ func (g *GravityClient) Start() error {
 	}
 	g.logger.Debug("control streams established successfully")
 
+	// Clear stale handshake signals before sending a new session hello.
+	// The control stream handler can receive SessionHelloResponse immediately
+	// after sendSessionHello returns; draining later can discard the valid
+	// machine ID and leave startup waiting until timeout.
+	g.drainConnectionIDChan()
+
 	g.logger.Debug("sending session hello...")
 	// Send session hello to authenticate and get session info
 	err = g.sendSessionHello()
@@ -1030,6 +1036,12 @@ func (g *GravityClient) startMultiEndpoint() error {
 		return fmt.Errorf("failed to establish control streams: %w", err)
 	}
 	g.logger.Debug("control streams established successfully")
+
+	// Clear stale handshake signals before sending a new session hello.
+	// The control stream handler can receive SessionHelloResponse immediately
+	// after sendSessionHello returns; draining later can discard the valid
+	// machine ID and leave startup waiting until timeout.
+	g.drainConnectionIDChan()
 
 	g.logger.Debug("sending session hello...")
 	err = g.sendSessionHello()
@@ -2116,9 +2128,6 @@ func (g *GravityClient) establishTunnelStreams() error {
 		g.logger.Debug("waiting for machine ID from server...")
 	}
 
-	// Drain any stale responses from previous sessions (reconnect path).
-	g.drainConnectionIDChan()
-
 	// Single shared deadline — don't let late responses extend the total wait.
 	// Track how many responses we received to only create tunnel streams on
 	// connections where the session hello was acknowledged.
@@ -2422,7 +2431,7 @@ func (g *GravityClient) handleControlStream(streamIndex int, stream pb.GravitySe
 				isCanceled = true
 				g.logger.Debug("control stream %d closed due to context cancellation", streamIndex)
 			} else {
-				g.logger.Error("control stream %d receive error: %v", streamIndex, err)
+				g.logControlStreamReceiveError(streamIndex, err)
 			}
 
 			// Trigger reconnection for any stream death unless we're
@@ -2432,6 +2441,9 @@ func (g *GravityClient) handleControlStream(streamIndex int, stream pb.GravitySe
 			closing := g.closing
 			g.mu.RUnlock()
 			if !closing {
+				if _, acked := g.helloAckedStreams.Load(streamIndex); !acked {
+					g.signalSessionHelloFailure(streamIndex, err)
+				}
 				isConnectionLost := isCanceled || errors.Is(err, io.EOF)
 				if !isConnectionLost {
 					if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
@@ -2452,6 +2464,26 @@ func (g *GravityClient) handleControlStream(streamIndex int, stream pb.GravitySe
 
 		g.logger.Trace("control stream %d received message: ID=%s, Type=%T", streamIndex, msg.Id, msg.MessageType)
 		g.processSessionMessage(streamIndex, msg)
+	}
+}
+
+func (g *GravityClient) logControlStreamReceiveError(streamIndex int, err error) {
+	if st, ok := status.FromError(err); ok {
+		g.logger.Error("control stream %d receive error: type=%T grpc_code=%s grpc_message=%q error=%q", streamIndex, err, st.Code().String(), st.Message(), err.Error())
+		for i, detail := range st.Details() {
+			g.logger.Error("control stream %d receive error detail %d: type=%T value=%+v", streamIndex, i, detail, detail)
+		}
+		return
+	}
+	g.logger.Error("control stream %d receive error: type=%T error=%q", streamIndex, err, err.Error())
+}
+
+func (g *GravityClient) signalSessionHelloFailure(streamIndex int, err error) {
+	g.logger.Error("control stream %d closed before session hello response; signaling startup failure: %s", streamIndex, err.Error())
+	select {
+	case g.connectionIDChan <- "":
+	default:
+		g.logger.Warn("control stream %d session hello failure signal dropped: connectionIDChan full", streamIndex)
 	}
 }
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -296,10 +296,11 @@ type GravityClient struct {
 	reconnecting         bool          // Tracks if reconnection is in progress
 	endpointReconnecting []atomic.Bool // Per-endpoint reconnect guard (multi-endpoint only)
 	endpointFailCount    []atomic.Int32
-	connectionIDs        []string      // Stores connection IDs from server responses
-	connectionIDChan     chan string   // Channel to signal when connection ID is received
-	helloAckedStreams    sync.Map      // streamIndex (int) → true: tracks which streams received SessionHelloResponse
-	sessionReady         chan struct{} // Closed when session is fully authenticated and configured
+	connectionIDs        []string                // Stores connection IDs from server responses
+	connectionIDChan     chan sessionHelloSignal // Channel to signal session hello results
+	sessionHelloChans    sync.Map                // streamIndex (int) → chan sessionHelloSignal for endpoint reconnect handshakes
+	helloAckedStreams    sync.Map                // streamIndex (int) → true: tracks which streams received SessionHelloResponse
+	sessionReady         chan struct{}           // Closed when session is fully authenticated and configured
 	otlpURL              string
 	otlpToken            string
 	apiURL               string
@@ -388,6 +389,11 @@ type GravityClient struct {
 
 	// network interface for routing
 	networkInterface network.NetworkInterface
+}
+
+type sessionHelloSignal struct {
+	streamIndex int
+	machineID   string
 }
 
 // StreamInfo tracks individual stream health and load
@@ -510,7 +516,7 @@ func New(config GravityConfig) (*GravityClient, error) {
 		caCert:                 config.CACert,
 		defaultServerName:      config.DefaultServerName,
 		connectionIDs:          make([]string, 0, poolConfig.PoolSize),
-		connectionIDChan:       make(chan string, max(1, poolConfig.PoolSize*len(config.GravityURLs))),
+		connectionIDChan:       make(chan sessionHelloSignal, max(1, poolConfig.PoolSize*len(config.GravityURLs))),
 		sessionReady:           make(chan struct{}),
 		response:               make(chan *pb.ProtocolResponse, 100),
 		pending:                make(map[string]chan *pb.ProtocolResponse),
@@ -2109,22 +2115,21 @@ func (g *GravityClient) establishTunnelStreams() error {
 	// processed the session hello before we open tunnel streams.
 	// Use len(g.connections) rather than raw g.gravityURLs because
 	// resolveGravityURLs() deduplicates and trims to MaxGravityPeers.
-	numExpected := 1
+	expectedStreams := make(map[int]bool)
 	if len(g.connections) > 1 {
 		g.streamManager.controlMu.RLock()
-		healthyCount := 0
-		for _, s := range g.streamManager.controlStreams {
+		for idx, s := range g.streamManager.controlStreams {
 			if s != nil {
-				healthyCount++
+				expectedStreams[idx] = true
 			}
 		}
 		g.streamManager.controlMu.RUnlock()
-		if healthyCount == 0 {
+		if len(expectedStreams) == 0 {
 			return fmt.Errorf("no healthy control streams available")
 		}
-		numExpected = healthyCount
-		g.logger.Debug("waiting for session hello responses from %d healthy Gravity servers (%d total)...", healthyCount, len(g.connections))
+		g.logger.Debug("waiting for session hello responses from %d healthy Gravity servers (%d total)...", len(expectedStreams), len(g.connections))
 	} else {
+		expectedStreams[0] = true
 		g.logger.Debug("waiting for machine ID from server...")
 	}
 
@@ -2133,31 +2138,55 @@ func (g *GravityClient) establishTunnelStreams() error {
 	// connections where the session hello was acknowledged.
 	var machineID string
 	helloResponseCount := 0
+	failedResponses := make(map[int]bool)
+	successResponses := make(map[int]bool)
 	deadline := time.NewTimer(time.Minute)
 	defer deadline.Stop()
-	for i := 0; i < numExpected; i++ {
+	for len(successResponses)+len(failedResponses) < len(expectedStreams) {
 		select {
-		case id := <-g.connectionIDChan:
-			if id == "" {
-				g.logger.Error("session failed - authentication rejected by server (response %d/%d)", i+1, numExpected)
-				return fmt.Errorf("session failed - authentication rejected by server")
+		case sig := <-g.connectionIDChan:
+			if !expectedStreams[sig.streamIndex] {
+				g.logger.Debug("ignoring session hello signal for unexpected stream %d", sig.streamIndex)
+				continue
+			}
+			if sig.machineID == "" {
+				failedResponses[sig.streamIndex] = true
+				g.logger.Error("session hello rejected by server on stream %d (%d/%d failures)", sig.streamIndex, len(failedResponses), len(expectedStreams))
+				if len(failedResponses) == len(expectedStreams) && helloResponseCount == 0 {
+					g.logger.Error("session failed - authentication rejected by all expected servers")
+					return fmt.Errorf("session failed - authentication rejected by server")
+				}
+				continue
+			}
+			if failedResponses[sig.streamIndex] {
+				g.logger.Debug("ignoring late session hello success for stream %d after failure", sig.streamIndex)
+				continue
+			}
+			if successResponses[sig.streamIndex] {
+				g.logger.Debug("ignoring duplicate session hello success for stream %d", sig.streamIndex)
+				continue
 			}
 			if machineID == "" {
-				machineID = id
+				machineID = sig.machineID
 			}
+			successResponses[sig.streamIndex] = true
 			helloResponseCount++
-			g.logger.Debug("session hello response %d/%d received (machine ID: %s)", i+1, numExpected, id)
+			g.logger.Debug("session hello response %d/%d received from stream %d (machine ID: %s)", helloResponseCount, len(expectedStreams), sig.streamIndex, sig.machineID)
 		case <-deadline.C:
-			if machineID != "" && i > 0 {
-				g.logger.Warn("timeout waiting for session hello response %d/%d, proceeding with %d responses", i+1, numExpected, i)
+			if machineID != "" {
+				g.logger.Warn("timeout waiting for remaining session hello responses, proceeding with %d/%d responses", helloResponseCount, len(expectedStreams))
 				goto proceed
+			}
+			if len(failedResponses) > 0 {
+				g.logger.Error("session failed - authentication rejected by %d/%d expected servers", len(failedResponses), len(expectedStreams))
+				return fmt.Errorf("session failed - authentication rejected by server")
 			}
 			g.logger.Error("timeout waiting for machine ID from server - possible server issue or network problem")
 			return fmt.Errorf("timeout waiting for machine ID from server")
 		}
 	}
 proceed:
-	g.logger.Debug("machine ID received: %s, proceeding with tunnel streams (%d/%d hellos acknowledged)", machineID, helloResponseCount, numExpected)
+	g.logger.Debug("machine ID received: %s, proceeding with tunnel streams (%d/%d hellos acknowledged)", machineID, helloResponseCount, len(expectedStreams))
 
 	// Build the set of connections that actually received a SessionHelloResponse.
 	// Tracked by helloAckedStreams (set in processSessionMessage when the response
@@ -2176,7 +2205,7 @@ proceed:
 	// If we got fewer responses than expected, mark non-responding endpoints unhealthy.
 	// Also mark connectionHealth[i] = false so refreshEndpointHealth() doesn't
 	// override our healthy=false with its connectionHealth-based rebuild.
-	if helloResponseCount < numExpected {
+	if helloResponseCount < len(expectedStreams) {
 		g.endpointsMu.RLock()
 		for i, ep := range g.endpoints {
 			if ep != nil && !helloAcked[i] {
@@ -2480,10 +2509,27 @@ func (g *GravityClient) logControlStreamReceiveError(streamIndex int, err error)
 
 func (g *GravityClient) signalSessionHelloFailure(streamIndex int, err error) {
 	g.logger.Error("control stream %d closed before session hello response; signaling startup failure: %s", streamIndex, err.Error())
+	g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex})
+}
+
+func (g *GravityClient) sendSessionHelloSignal(sig sessionHelloSignal) bool {
+	if chValue, ok := g.sessionHelloChans.Load(sig.streamIndex); ok {
+		ch := chValue.(chan sessionHelloSignal)
+		select {
+		case ch <- sig:
+			return true
+		default:
+			g.logger.Warn("session hello signal dropped for stream %d: endpoint channel full", sig.streamIndex)
+			return false
+		}
+	}
+
 	select {
-	case g.connectionIDChan <- "":
+	case g.connectionIDChan <- sig:
+		return true
 	default:
-		g.logger.Warn("control stream %d session hello failure signal dropped: connectionIDChan full", streamIndex)
+		g.logger.Warn("session hello signal dropped for stream %d: shared channel full", sig.streamIndex)
+		return false
 	}
 }
 
@@ -2688,7 +2734,7 @@ func (g *GravityClient) processSessionMessage(streamIndex int, msg *pb.SessionMe
 	case *pb.SessionMessage_Resume:
 		g.handleResumeRequest(streamIndex, msg.Id, m.Resume)
 	case *pb.SessionMessage_Response:
-		g.handleGenericResponse(msg.Id, m.Response)
+		g.handleGenericResponse(streamIndex, msg.Id, m.Response)
 	case *pb.SessionMessage_Event:
 		g.handleEvent(streamIndex, msg.Id, m.Event)
 	case *pb.SessionMessage_Pong:
@@ -2798,15 +2844,12 @@ func (g *GravityClient) handleSessionHelloResponse(streamIndex int, msgID string
 	g.mu.Unlock()
 
 	signalConnectionID := func(id string) {
-		select {
-		case g.connectionIDChan <- id:
+		if g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex, machineID: id}) {
 			if id == "" {
 				g.logger.Debug("sent empty machine ID to signal session hello failure")
 			} else {
-				g.logger.Debug("machine ID sent to channel successfully")
+				g.logger.Debug("machine ID sent to channel successfully for stream %d", streamIndex)
 			}
-		default:
-			g.logger.Warn("connectionIDChan full, dropped machine ID signal")
 		}
 	}
 
@@ -2984,17 +3027,15 @@ func (g *GravityClient) tunnelReadyEndpointIndices() []int {
 	return nil
 }
 
-func (g *GravityClient) handleGenericResponse(msgID string, response *pb.ProtocolResponse) {
+func (g *GravityClient) handleGenericResponse(streamIndex int, msgID string, response *pb.ProtocolResponse) {
 	g.logger.Trace("received generic response: msgID=%s, success=%v, error=%s, event=%s",
 		msgID, response.Success, response.Error, response.Event)
 
 	// Check if this is an error response for a session hello message
 	if msgID == "session_hello" && !response.Success {
 		g.logger.Error("session hello failed: %s", response.Error)
-		select {
-		case g.connectionIDChan <- "":
-		default:
-			g.logger.Warn("session hello failure: connectionIDChan full, failure signal dropped")
+		if !g.sendSessionHelloSignal(sessionHelloSignal{streamIndex: streamIndex}) {
+			g.logger.Warn("session hello failure signal dropped for stream %d", streamIndex)
 		}
 		return
 	}
@@ -4520,6 +4561,10 @@ func (g *GravityClient) reconnectSingleEndpoint(endpointIndex int, endpointURL s
 	g.streamManager.cancels[endpointIndex] = cancel
 	g.streamManager.controlMu.Unlock()
 
+	helloCh := make(chan sessionHelloSignal, 1)
+	g.sessionHelloChans.Store(endpointIndex, helloCh)
+	defer g.sessionHelloChans.Delete(endpointIndex)
+
 	go g.handleControlStream(endpointIndex, stream)
 
 	g.drainConnectionIDChan()
@@ -4529,23 +4574,29 @@ func (g *GravityClient) reconnectSingleEndpoint(endpointIndex int, endpointURL s
 		return fmt.Errorf("failed to send session hello: %w", err)
 	}
 
-	select {
-	case id := <-g.connectionIDChan:
-		if id == "" {
+	deadline := time.NewTimer(30 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case sig := <-helloCh:
+			if sig.machineID == "" {
+				cancel()
+				_ = conn.Close()
+				return fmt.Errorf("session hello rejected by server")
+			}
+			g.logger.Debug("endpoint %d session hello accepted (machine ID: %s)", endpointIndex, sig.machineID)
+			goto accepted
+		case <-deadline.C:
 			cancel()
 			_ = conn.Close()
-			return fmt.Errorf("session hello rejected by server")
+			return fmt.Errorf("timeout waiting for session hello response")
+		case <-g.ctx.Done():
+			cancel()
+			_ = conn.Close()
+			return g.ctx.Err()
 		}
-		g.logger.Debug("endpoint %d session hello accepted (machine ID: %s)", endpointIndex, id)
-	case <-time.After(30 * time.Second):
-		cancel()
-		_ = conn.Close()
-		return fmt.Errorf("timeout waiting for session hello response")
-	case <-g.ctx.Done():
-		cancel()
-		_ = conn.Close()
-		return g.ctx.Err()
 	}
+accepted:
 
 	// Handshake succeeded — now mark the connection healthy so
 	// sendSessionMessageAsync and stream selectors can use it.

--- a/gravity/hardening_test.go
+++ b/gravity/hardening_test.go
@@ -274,10 +274,10 @@ func TestHardening_ReconnectDrainsAllConnectionIDs(t *testing.T) {
 	g := newHardeningGravityClient(t, 1)
 
 	// Push multiple stale IDs into the real channel.
-	g.connectionIDChan <- "a"
-	g.connectionIDChan <- "b"
-	g.connectionIDChan <- "c"
-	g.connectionIDChan <- "d"
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 0, machineID: "a"}
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 1, machineID: "b"}
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 2, machineID: "c"}
+	g.connectionIDChan <- sessionHelloSignal{streamIndex: 3, machineID: "d"}
 
 	// Call the production drain helper used by reconnect().
 	g.drainConnectionIDChan()
@@ -696,9 +696,9 @@ func TestHardening_SessionHelloConfigureFailureUnblocksWait(t *testing.T) {
 	}
 
 	select {
-	case id := <-g.connectionIDChan:
-		if id != "" {
-			t.Fatalf("expected empty machine ID failure signal, got %q", id)
+	case sig := <-g.connectionIDChan:
+		if sig.streamIndex != 0 || sig.machineID != "" {
+			t.Fatalf("expected empty machine ID failure signal for stream 0, got %+v", sig)
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected failure signal on connectionIDChan")
@@ -1734,6 +1734,7 @@ func TestTunnelReadyEndpointIndices_SingleEndpointModeUsesHealthyConnection(t *t
 		t.Fatalf("expected single-endpoint mode to report endpoint 0 ready, got %v", ready)
 	}
 }
+
 // ============================================================================
 // P3: Timing & Lifecycle Tests
 // ============================================================================

--- a/gravity/hardening_test.go
+++ b/gravity/hardening_test.go
@@ -700,6 +700,9 @@ func TestHardening_SessionHelloConfigureFailureUnblocksWait(t *testing.T) {
 		if sig.streamIndex != 0 || sig.machineID != "" {
 			t.Fatalf("expected empty machine ID failure signal for stream 0, got %+v", sig)
 		}
+		if sig.errMessage == "" {
+			t.Fatal("expected configure failure message on session hello signal")
+		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected failure signal on connectionIDChan")
 	}

--- a/gravity/route_response_test.go
+++ b/gravity/route_response_test.go
@@ -58,10 +58,10 @@ func TestHandleGenericResponse_ErrorRoutesToSandboxPending(t *testing.T) {
 		pending:                make(map[string]chan *pb.ProtocolResponse),
 		pendingRouteSandbox:    map[string]chan routeSandboxResult{msgID: resultChan},
 		pendingRouteDeployment: make(map[string]chan routeDeploymentResult),
-		connectionIDChan:       make(chan string, 1),
+		connectionIDChan:       make(chan sessionHelloSignal, 1),
 	}
 
-	g.handleGenericResponse(msgID, &pb.ProtocolResponse{Id: msgID, Success: false, Error: "boom"})
+	g.handleGenericResponse(0, msgID, &pb.ProtocolResponse{Id: msgID, Success: false, Error: "boom"})
 
 	select {
 	case result := <-resultChan:
@@ -82,10 +82,10 @@ func TestHandleGenericResponse_ErrorRoutesToDeploymentPending(t *testing.T) {
 		pending:                make(map[string]chan *pb.ProtocolResponse),
 		pendingRouteSandbox:    make(map[string]chan routeSandboxResult),
 		pendingRouteDeployment: map[string]chan routeDeploymentResult{msgID: resultChan},
-		connectionIDChan:       make(chan string, 1),
+		connectionIDChan:       make(chan sessionHelloSignal, 1),
 	}
 
-	g.handleGenericResponse(msgID, &pb.ProtocolResponse{Id: msgID, Success: false, Error: "boom"})
+	g.handleGenericResponse(0, msgID, &pb.ProtocolResponse{Id: msgID, Success: false, Error: "boom"})
 
 	select {
 	case result := <-resultChan:
@@ -107,10 +107,10 @@ func TestHandleGenericResponse_SuccessDoesNotRouteToSandbox(t *testing.T) {
 		pending:                map[string]chan *pb.ProtocolResponse{msgID: responseChan},
 		pendingRouteSandbox:    map[string]chan routeSandboxResult{msgID: resultChan},
 		pendingRouteDeployment: make(map[string]chan routeDeploymentResult),
-		connectionIDChan:       make(chan string, 1),
+		connectionIDChan:       make(chan sessionHelloSignal, 1),
 	}
 
-	g.handleGenericResponse(msgID, &pb.ProtocolResponse{Id: msgID, Success: true})
+	g.handleGenericResponse(0, msgID, &pb.ProtocolResponse{Id: msgID, Success: true})
 
 	select {
 	case response := <-responseChan:
@@ -134,10 +134,10 @@ func TestHandleGenericResponse_ErrorNotFoundAnywhere(t *testing.T) {
 		pending:                make(map[string]chan *pb.ProtocolResponse),
 		pendingRouteSandbox:    make(map[string]chan routeSandboxResult),
 		pendingRouteDeployment: make(map[string]chan routeDeploymentResult),
-		connectionIDChan:       make(chan string, 1),
+		connectionIDChan:       make(chan sessionHelloSignal, 1),
 	}
 
-	g.handleGenericResponse("missing", &pb.ProtocolResponse{Id: "missing", Success: false, Error: "boom"})
+	g.handleGenericResponse(0, "missing", &pb.ProtocolResponse{Id: "missing", Success: false, Error: "boom"})
 }
 
 func TestSendRouteSandboxRequest_ErrorFromServer(t *testing.T) {

--- a/gravity/tunnel_dataplane_test.go
+++ b/gravity/tunnel_dataplane_test.go
@@ -476,7 +476,7 @@ func TestStreamManager_RegisterStream(t *testing.T) {
 	g.helloAckedStreams.Store(0, true)
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		g.connectionIDChan <- "machine-1"
+		g.connectionIDChan <- sessionHelloSignal{streamIndex: 0, machineID: "machine-1"}
 	}()
 
 	if err := g.establishTunnelStreams(); err != nil {


### PR DESCRIPTION
## Summary
- drain stale session hello IDs before sending a new hello so fast responses are not discarded
- log concrete control stream receive error details, including gRPC code/message
- fail startup immediately when a control stream closes before SessionHelloResponse instead of waiting for the outer validation timeout

## Validation
- go test -race -count=1 ./gravity

## Context
This makes `hadron validate` surface auth failures such as an unregistered public key instead of timing out with an opaque control stream receive error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and updated resilience tests covering per-stream handshake behavior, unexpected-stream handling, pre-hello failure signaling, endpoint-specific handshake delivery, handler-level error signaling, and channel-capacity scaling.

* **Bug Fixes**
  * Improved handshake signaling and stale-signal draining to avoid misrouting and races.
  * Clearer, faster failure detection and propagation for control-stream/authentication errors.
  * Ensured endpoint-specific routing and improved logging/diagnostics for session startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->