### PR TITLE
Disable peer discovery for direct IP gravity URLs

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -242,6 +242,7 @@ type GravityClient struct {
 	peerCycleInterval       time.Duration
 	lastCycleTime           atomic.Int64  // unix timestamp of last cycle
 	peerDiscoveryWake       chan struct{} // non-blocking signal to wake the discovery loop immediately
+	peerDiscoveryDisabled   bool
 	discoveryCtx            context.Context
 	discoveryCancel         context.CancelFunc
 	discoveryDone           chan struct{}
@@ -835,6 +836,7 @@ func (g *GravityClient) startMultiEndpoint() error {
 		g.mu.Unlock()
 		return ErrNoGravityFound
 	}
+	g.peerDiscoveryDisabled = allGravityURLsAreDirectIPs(urls)
 	g.mu.Unlock()
 
 	g.logger.Info("multi-endpoint mode: connecting to %d Gravity servers: %v", len(urls), urls)
@@ -1188,6 +1190,50 @@ func (g *GravityClient) resolveGravityURLs() []string {
 	}
 
 	return urls
+}
+
+func allGravityURLsAreDirectIPs(urls []string) bool {
+	hasURL := false
+	for _, raw := range urls {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		hasURL = true
+		if !isDirectIPGravityURL(raw) {
+			return false
+		}
+	}
+	return hasURL
+}
+
+func isDirectIPGravityURL(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+
+	if ip := net.ParseIP(strings.Trim(raw, "[]")); ip != nil {
+		return true
+	}
+
+	parseable := raw
+	if strings.HasPrefix(parseable, "grpc://") {
+		parseable = "https://" + parseable[len("grpc://"):]
+	} else if !strings.Contains(parseable, "://") {
+		parseable = "https://" + parseable
+	}
+
+	u, err := url.Parse(parseable)
+	if err != nil {
+		return false
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	return net.ParseIP(host) != nil
 }
 
 // tunnelLivenessMonitor periodically sends keepalive probes on tunnel streams
@@ -5044,6 +5090,10 @@ func (g *GravityClient) cleanup() {
 
 func (g *GravityClient) startPeerDiscovery() {
 	if g.discoveryResolveFunc == nil {
+		return
+	}
+	if g.peerDiscoveryDisabled {
+		g.logger.Debug("peer discovery: disabled for direct IP Gravity URLs")
 		return
 	}
 

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -198,6 +198,58 @@ func TestResolveGravityURLs_MaxPeersZeroIncludesAll(t *testing.T) {
 	}
 }
 
+func TestAllGravityURLsAreDirectIPs(t *testing.T) {
+	tests := []struct {
+		name string
+		urls []string
+		want bool
+	}{
+		{
+			name: "single IPv4 URL",
+			urls: []string{"grpc://10.0.0.1:443"},
+			want: true,
+		},
+		{
+			name: "multiple IPv4 URLs",
+			urls: []string{"grpc://10.0.0.1:443", "grpc://10.0.0.2:443"},
+			want: true,
+		},
+		{
+			name: "bracketed IPv6 URL",
+			urls: []string{"grpc://[fd15:d710::1]:443"},
+			want: true,
+		},
+		{
+			name: "hostnames are not direct IPs",
+			urls: []string{"grpc://gravity.example.com:443"},
+			want: false,
+		},
+		{
+			name: "mixed hostname and IP keeps discovery enabled",
+			urls: []string{"grpc://10.0.0.1:443", "grpc://gravity.example.com:443"},
+			want: false,
+		},
+		{
+			name: "empty input",
+			urls: []string{"", "  "},
+			want: false,
+		},
+		{
+			name: "host port without scheme",
+			urls: []string{"10.0.0.1:443"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allGravityURLsAreDirectIPs(tt.urls); got != tt.want {
+				t.Fatalf("allGravityURLsAreDirectIPs(%#v) = %v, want %v", tt.urls, got, tt.want)
+			}
+		})
+	}
+}
+
 // ---------- pickRandomURL ----------
 
 func TestPickRandomURL_SingleElement(t *testing.T) {
@@ -816,6 +868,29 @@ func TestCleanup_CancelsPeerDiscoveryLoop(t *testing.T) {
 	case <-called:
 		t.Fatal("expected canceled peer discovery loop to stop scheduling reconnects")
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestStartPeerDiscovery_DisabledForDirectIPGravityURLs(t *testing.T) {
+	g := newTestGravityClient([]string{"grpc://10.0.0.1:443"}, []string{"grpc://10.0.0.1:443"})
+	defer g.cancel()
+
+	g.peerDiscoveryWake = make(chan struct{}, 1)
+	g.discoveryResolveFunc = func() []string {
+		t.Fatal("discovery resolver should not be called for direct IP Gravity URLs")
+		return nil
+	}
+	g.peerDiscoveryDisabled = allGravityURLsAreDirectIPs(g.gravityURLs)
+
+	g.startPeerDiscovery()
+
+	g.discoveryMu.Lock()
+	discoveryCtx := g.discoveryCtx
+	discoveryDone := g.discoveryDone
+	g.discoveryMu.Unlock()
+
+	if discoveryCtx != nil || discoveryDone != nil {
+		t.Fatal("expected peer discovery loop not to start for direct IP Gravity URLs")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Detect when Gravity is configured entirely with literal IP URLs
- Skip starting the peer discovery loop for those static direct-IP configurations
- Add coverage for IPv4, IPv6, mixed hostname/IP, and disabled discovery startup

## Tests
- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Peer discovery is now automatically optimized and disabled when all configured Gravity service endpoints are direct IP addresses.

* **Tests**
  * Added comprehensive test coverage for endpoint IP detection and peer discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->