### PR TITLE
fix(gravity): identify health probes

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -92,6 +92,11 @@ const (
 	// ipv6 destination" → RST, breaking HTTP/2 connection reuse and
 	// long-lived connections.
 	DefaultBindingTTL = 10 * time.Minute
+
+	// GravityHealthProbeUserAgent identifies hadron/gravity-client HTTP
+	// readiness probes to ion. Ion uses this to answer control-plane
+	// readiness without admitting public traffic during tableflip.
+	GravityHealthProbeUserAgent = "Agentuity-Gravity-HealthProbe/1.0"
 )
 
 // TunnelKeepaliveMarker is a 4-byte magic prefix for tunnel keepalive packets.
@@ -4539,6 +4544,7 @@ func (g *GravityClient) doHealthProbe(probeURL string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	req.Header.Set("User-Agent", GravityHealthProbeUserAgent)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, err

--- a/gravity/health_probe_test.go
+++ b/gravity/health_probe_test.go
@@ -1,0 +1,39 @@
+package gravity
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentuity/go-common/logger"
+)
+
+func TestDoHealthProbeSetsGravityUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var gotUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g := &GravityClient{
+		context: ctx,
+		logger:  logger.NewTestLogger(),
+	}
+
+	status, err := g.doHealthProbe(srv.URL)
+	if err != nil {
+		t.Fatalf("doHealthProbe returned error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+	if gotUserAgent != GravityHealthProbeUserAgent {
+		t.Fatalf("expected User-Agent %q, got %q", GravityHealthProbeUserAgent, gotUserAgent)
+	}
+}


### PR DESCRIPTION
## Summary
- set a distinct User-Agent on Gravity HTTP health probes
- add a regression test covering the probe User-Agent

## Validation
- go test ./gravity

This lets ion distinguish hadron/gravity reconnect probes from public health checks during tableflip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health probe requests to include an identifying User-Agent header for better request traceability.

* **Tests**
  * Added test coverage for health probe User-Agent header validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->