### PR TITLE
fix(gravity): repair duplicate peer slots

### DIFF
--- a/gravity/endpoint_independence_test.go
+++ b/gravity/endpoint_independence_test.go
@@ -1199,8 +1199,14 @@ func setupWritePacketStreams(g *GravityClient, streams []*StreamInfo) {
 		if s == nil {
 			continue
 		}
+		if s.connIndex < 0 || s.connIndex >= len(g.connectionURLs) {
+			continue
+		}
 		url := g.connectionURLs[s.connIndex]
 		g.endpointStreamIndices[url] = append(g.endpointStreamIndices[url], idx)
+		if s.isHealthy && s.connIndex >= 0 && s.connIndex < len(g.streamManager.controlStreams) && g.streamManager.controlStreams[s.connIndex] == nil {
+			g.streamManager.controlStreams[s.connIndex] = &configurableMockStream{}
+		}
 	}
 	for _, s := range streams {
 		if s == nil {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4605,24 +4605,12 @@ func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL
 
 		if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
 			g.endpoints[endpointIndex].URL = u
-			g.endpoints[endpointIndex].TLSServerName = g.tlsServerNameFromParsedURL(u)
+			g.endpoints[endpointIndex].TLSServerName = g.preferredTLSServerName(u)
 		}
 		return u, true
 	}
 
 	return "", false
-}
-
-func (g *GravityClient) tlsServerNameFromParsedURL(endpointURL string) string {
-	parsed, err := g.parseGRPCURL(endpointURL)
-	if err != nil {
-		return ""
-	}
-	host, _, err := net.SplitHostPort(parsed)
-	if err != nil || net.ParseIP(host) != nil {
-		return ""
-	}
-	return host
 }
 
 // probeHealthEndpoint checks if a gravity endpoint is alive and ready by

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1786,6 +1786,9 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 	if currentCount < maxPeers && len(newURLs) > 0 {
 		newURL := pickRandomURL(newURLs)
 		if newURL != "" {
+			if g.replaceDuplicateEndpoint(newURL) {
+				return
+			}
 			g.logger.Info("peer discovery: adding new endpoint %s (currently %d/%d, %d new available)",
 				newURL, currentCount, maxPeers, len(newURLs))
 			g.addEndpoint(newURL)
@@ -1824,6 +1827,43 @@ func (g *GravityClient) checkPeerDiscovery(cycleInterval time.Duration) {
 		evictURL, newURL, len(allURLs), currentCount)
 	g.cycleEndpoint(evictURL, newURL)
 	g.lastCycleTime.Store(now.Unix())
+}
+
+// replaceDuplicateEndpoint repairs a full endpoint set where two slots point at
+// the same Gravity URL and peer discovery has found a missing discovered URL.
+func (g *GravityClient) replaceDuplicateEndpoint(newURL string) bool {
+	if strings.TrimSpace(newURL) == "" {
+		return false
+	}
+
+	g.endpointsMu.RLock()
+	counts := make(map[string]int, len(g.endpoints))
+	for _, ep := range g.endpoints {
+		if ep == nil {
+			continue
+		}
+		u := strings.TrimSpace(ep.URL)
+		if u != "" {
+			counts[u]++
+		}
+	}
+
+	duplicateURL := ""
+	for u, count := range counts {
+		if count > 1 {
+			duplicateURL = u
+			break
+		}
+	}
+	g.endpointsMu.RUnlock()
+
+	if duplicateURL == "" {
+		return false
+	}
+
+	g.logger.Info("peer discovery: replacing duplicate connection %s with %s", duplicateURL, newURL)
+	g.cycleEndpoint(duplicateURL, newURL)
+	return true
 }
 
 // cycleEndpoint replaces one endpoint with another.
@@ -4411,7 +4451,7 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 	// hostname that discovery returned. Re-resolving TLSServerName can therefore
 	// collapse multiple direct endpoints back onto the same shared/NLB address.
 	if g.multiEndpointMode.Load() && g.discoveryResolveFunc != nil {
-		if newURL, handled := g.reResolveFromDiscoveredSet(endpointIndex, currentURL, inUse); handled {
+		if newURL, handled := g.reResolveFromDiscoveredSet(endpointIndex, currentURL); handled {
 			return newURL
 		}
 	}
@@ -4500,7 +4540,7 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 	return ""
 }
 
-func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL string, inUse map[string]bool) (string, bool) {
+func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL string) (string, bool) {
 	allURLs := g.discoveryResolveFunc()
 	if len(allURLs) == 0 {
 		return "", false
@@ -4522,6 +4562,31 @@ func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL
 		return "", false
 	}
 
+	// Preserve direct discovered endpoint coverage. If this endpoint is still
+	// in the discovered set, retry it instead of collapsing onto another live
+	// Ion and leaving this direct target uncovered.
+	if currentKnown {
+		return "", true
+	}
+
+	g.endpointsMu.Lock()
+	defer g.endpointsMu.Unlock()
+
+	inUse := make(map[string]bool, len(g.endpoints))
+	for i, ep := range g.endpoints {
+		if i == endpointIndex || ep == nil {
+			continue
+		}
+		parsed, err := g.parseGRPCURL(ep.URL)
+		if err != nil {
+			continue
+		}
+		host, _, splitErr := net.SplitHostPort(parsed)
+		if splitErr == nil {
+			inUse[host] = true
+		}
+	}
+
 	// First try to switch to another discovered direct endpoint that is not
 	// already in use by a sibling endpoint.
 	for _, raw := range allURLs {
@@ -4538,19 +4603,10 @@ func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL
 			continue
 		}
 
-		g.endpointsMu.Lock()
 		if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
 			g.endpoints[endpointIndex].URL = u
 		}
-		g.endpointsMu.Unlock()
 		return u, true
-	}
-
-	// If the current endpoint is already part of the discovered direct set and
-	// there is no unique replacement, keep retrying it rather than falling back
-	// to the shared bootstrap/NLB hostname via TLSServerName DNS.
-	if currentKnown {
-		return "", true
 	}
 
 	return "", false

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -5003,7 +5003,14 @@ func (g *GravityClient) attemptReconnection(reason string) {
 		attemptTimeout = 2 * time.Minute // Default: 2 minutes per attempt
 	}
 
-	for !g.closing {
+	for {
+		g.mu.RLock()
+		closing := g.closing
+		g.mu.RUnlock()
+		if closing {
+			break
+		}
+
 		attempts++
 		if maxAttempts > 0 {
 			g.logger.Info("reconnection attempt %d/%d (backoff: %v, timeout: %v)", attempts, maxAttempts, backoff, attemptTimeout)

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4541,8 +4541,8 @@ func (g *GravityClient) reResolveEndpointURL(endpointIndex int, currentURL strin
 }
 
 func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL string) (string, bool) {
-	allURLs := g.discoveryResolveFunc()
-	if len(allURLs) == 0 {
+	allURLs, ok := g.resolvePeerDiscoveryURLs()
+	if !ok || len(allURLs) == 0 {
 		return "", false
 	}
 
@@ -4605,11 +4605,24 @@ func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL
 
 		if endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil {
 			g.endpoints[endpointIndex].URL = u
+			g.endpoints[endpointIndex].TLSServerName = g.tlsServerNameFromParsedURL(u)
 		}
 		return u, true
 	}
 
 	return "", false
+}
+
+func (g *GravityClient) tlsServerNameFromParsedURL(endpointURL string) string {
+	parsed, err := g.parseGRPCURL(endpointURL)
+	if err != nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(parsed)
+	if err != nil || net.ParseIP(host) != nil {
+		return ""
+	}
+	return host
 }
 
 // probeHealthEndpoint checks if a gravity endpoint is alive and ready by

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -4579,15 +4579,17 @@ func (g *GravityClient) reResolveFromDiscoveredSet(endpointIndex int, currentURL
 		return "", false
 	}
 
-	// Preserve direct discovered endpoint coverage. If this endpoint is still
-	// in the discovered set, retry it instead of collapsing onto another live
-	// Ion and leaving this direct target uncovered.
-	if currentKnown {
-		return "", true
-	}
-
 	g.endpointsMu.Lock()
 	defer g.endpointsMu.Unlock()
+
+	// Preserve direct discovered endpoint coverage. If this endpoint is still
+	// in the discovered set, retry it instead of collapsing onto another live
+	// Ion and leaving this direct target uncovered. Only do this while the
+	// reconnecting slot still points at currentURL; endpointReconnecting can
+	// keep an older reconnect active after peer discovery retargets the slot.
+	if currentKnown && endpointIndex >= 0 && endpointIndex < len(g.endpoints) && g.endpoints[endpointIndex] != nil && g.endpoints[endpointIndex].URL == currentURL {
+		return "", true
+	}
 
 	inUse := make(map[string]bool, len(g.endpoints))
 	for i, ep := range g.endpoints {

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -1836,33 +1836,35 @@ func (g *GravityClient) replaceDuplicateEndpoint(newURL string) bool {
 		return false
 	}
 
-	g.endpointsMu.RLock()
-	counts := make(map[string]int, len(g.endpoints))
-	for _, ep := range g.endpoints {
+	g.endpointsMu.Lock()
+	seen := make(map[string]int, len(g.endpoints))
+	duplicateIdx := -1
+	for i, ep := range g.endpoints {
 		if ep == nil {
 			continue
 		}
 		u := strings.TrimSpace(ep.URL)
-		if u != "" {
-			counts[u]++
+		if u == "" {
+			continue
 		}
-	}
-
-	duplicateURL := ""
-	for u, count := range counts {
-		if count > 1 {
-			duplicateURL = u
+		if _, ok := seen[u]; ok {
+			duplicateIdx = i
 			break
 		}
+		seen[u] = i
 	}
-	g.endpointsMu.RUnlock()
-
-	if duplicateURL == "" {
+	if duplicateIdx < 0 {
+		g.endpointsMu.Unlock()
+		return false
+	}
+	duplicateURL, ok := g.cycleEndpointAtLocked(duplicateIdx, newURL)
+	g.endpointsMu.Unlock()
+	if !ok {
 		return false
 	}
 
 	g.logger.Info("peer discovery: replacing duplicate connection %s with %s", duplicateURL, newURL)
-	g.cycleEndpoint(duplicateURL, newURL)
+	g.finishEndpointCycle(duplicateIdx, duplicateURL, newURL)
 	return true
 }
 
@@ -1887,25 +1889,40 @@ func (g *GravityClient) cycleEndpoint(oldURL, newURL string) {
 		g.logger.Debug("peer discovery: endpoint %s already removed", oldURL)
 		return
 	}
+	replacedURL, ok := g.cycleEndpointAtLocked(oldIdx, newURL)
+	g.endpointsMu.Unlock()
+	if !ok {
+		return
+	}
 
+	g.finishEndpointCycle(oldIdx, replacedURL, newURL)
+}
+
+func (g *GravityClient) cycleEndpointAtLocked(endpointIndex int, newURL string) (string, bool) {
+	if strings.TrimSpace(newURL) == "" || endpointIndex < 0 || endpointIndex >= len(g.endpoints) || g.endpoints[endpointIndex] == nil {
+		return "", false
+	}
+	oldURL := g.endpoints[endpointIndex].URL
 	newEp := &GravityEndpoint{URL: newURL, TLSServerName: g.preferredTLSServerName(newURL)}
 	newEp.healthy.Store(false)
-	g.endpoints[oldIdx] = newEp
-	g.endpointsMu.Unlock()
+	g.endpoints[endpointIndex] = newEp
+	return oldURL, true
+}
 
+func (g *GravityClient) finishEndpointCycle(endpointIndex int, oldURL string, newURL string) {
 	g.mu.Lock()
-	if oldIdx >= 0 && oldIdx < len(g.connectionURLs) {
-		g.connectionURLs[oldIdx] = ""
+	if endpointIndex >= 0 && endpointIndex < len(g.connectionURLs) {
+		g.connectionURLs[endpointIndex] = ""
 	}
 	g.mu.Unlock()
 
 	g.logger.Info("peer discovery: endpoint cycled: removed %s, added %s", oldURL, newURL)
-	g.disconnectEndpointStreams(oldIdx)
-	g.scheduleEndpointReconnect(oldIdx, "peer_discovery_cycle")
+	g.disconnectEndpointStreams(endpointIndex)
+	g.scheduleEndpointReconnect(endpointIndex, "peer_discovery_cycle")
 
 	g.mu.Lock()
-	if oldIdx >= 0 && oldIdx < len(g.connectionURLs) {
-		g.connectionURLs[oldIdx] = newURL
+	if endpointIndex >= 0 && endpointIndex < len(g.connectionURLs) {
+		g.connectionURLs[endpointIndex] = newURL
 	}
 	g.mu.Unlock()
 }
@@ -5108,13 +5125,23 @@ func (g *GravityClient) reconnectWithTimeout(timeout time.Duration) error {
 // reconnect resets connection state and attempts to start a new connection
 func (g *GravityClient) reconnect() error {
 	g.logger.Debug("reconnect called")
+	g.mu.Lock()
+	if g.closing {
+		g.mu.Unlock()
+		return context.Canceled
+	}
+	g.mu.Unlock()
+
 	g.stopPeerDiscovery()
 
 	// Reset connection state without holding lock during Start()
 	g.mu.Lock()
+	if g.closing {
+		g.mu.Unlock()
+		return context.Canceled
+	}
 	g.ensureConnectionContextLocked()
 	g.connected = false
-	g.closing = false // Reset closing flag to allow reconnection
 	g.initialStartupDone.Store(false)
 	g.sessionReady = make(chan struct{})
 

--- a/gravity/hardening_test.go
+++ b/gravity/hardening_test.go
@@ -383,6 +383,25 @@ func TestHardening_WritePacketWhenClosing(t *testing.T) {
 	}
 }
 
+func TestHardening_ReconnectDoesNotClearClosing(t *testing.T) {
+	g := newHardeningGravityClient(t, 1)
+	g.mu.Lock()
+	g.closing = true
+	g.mu.Unlock()
+
+	err := g.reconnect()
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	g.mu.RLock()
+	closing := g.closing
+	g.mu.RUnlock()
+	if !closing {
+		t.Fatal("reconnect must not clear closing")
+	}
+}
+
 func TestHardening_ConcurrentCloseAndWritePacket(t *testing.T) {
 	g := newHardeningGravityClient(t, 1)
 	g.streamManager.allocationStrategy = RoundRobin

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -645,6 +645,48 @@ func TestCheckPeerDiscovery_ReplacesDuplicateEndpointWhenAtCapacity(t *testing.T
 	}
 }
 
+func TestReplaceDuplicateEndpoint_TargetsDuplicateSlot(t *testing.T) {
+	g := newTestGravityClient(nil, []string{
+		"grpc://10.0.0.1:443",
+		"grpc://10.0.0.2:443",
+		"grpc://10.0.0.2:443",
+	})
+	defer g.cancel()
+
+	reconnectIdx := -1
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		reconnectIdx = idx
+		if idx >= 0 && idx < len(g.endpointReconnecting) {
+			g.endpointReconnecting[idx].Store(false)
+		}
+	}
+
+	if !g.replaceDuplicateEndpoint("grpc://10.0.0.3:443") {
+		t.Fatal("expected duplicate endpoint to be replaced")
+	}
+
+	g.endpointsMu.RLock()
+	got := make([]string, len(g.endpoints))
+	for i, ep := range g.endpoints {
+		got[i] = ep.URL
+	}
+	g.endpointsMu.RUnlock()
+
+	want := []string{
+		"grpc://10.0.0.1:443",
+		"grpc://10.0.0.2:443",
+		"grpc://10.0.0.3:443",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("endpoint[%d]: expected %s, got %s (all=%v)", i, want[i], got[i], got)
+		}
+	}
+	if reconnectIdx != 2 {
+		t.Fatalf("expected duplicate slot 2 to reconnect, got %d", reconnectIdx)
+	}
+}
+
 func TestCheckPeerDiscovery_NewURLDiscovered(t *testing.T) {
 	// Connected to g1, g2, g3. DNS returns g1, g2, g3, g4.
 	// More URLs available than connected -- should cycle one endpoint.

--- a/gravity/peer_discovery_test.go
+++ b/gravity/peer_discovery_test.go
@@ -592,6 +592,59 @@ func TestCheckPeerDiscovery_DNSDiscoveredDirectIPAddsEndpointBelowCapacity(t *te
 	}
 }
 
+func TestCheckPeerDiscovery_ReplacesDuplicateEndpointWhenAtCapacity(t *testing.T) {
+	connected := []string{
+		"grpc://10.0.0.1:443",
+		"grpc://10.0.0.2:443",
+		"grpc://10.0.0.2:443",
+	}
+	g := newTestGravityClient(nil, connected)
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://10.0.0.1:443",
+			"grpc://10.0.0.2:443",
+			"grpc://10.0.0.3:443",
+		}
+	}
+	g.poolConfig.MaxGravityPeers = 3
+
+	reconnectIdx := -1
+	var reconnectReason string
+	g.reconnectEndpointHook = func(idx int, reason string) {
+		reconnectIdx = idx
+		reconnectReason = reason
+		if idx >= 0 && idx < len(g.endpointReconnecting) {
+			g.endpointReconnecting[idx].Store(false)
+		}
+	}
+
+	g.checkPeerDiscovery(2 * time.Hour)
+
+	g.endpointsMu.RLock()
+	urls := make(map[string]int)
+	for _, ep := range g.endpoints {
+		urls[ep.URL]++
+	}
+	g.endpointsMu.RUnlock()
+
+	for _, want := range []string{
+		"grpc://10.0.0.1:443",
+		"grpc://10.0.0.2:443",
+		"grpc://10.0.0.3:443",
+	} {
+		if urls[want] != 1 {
+			t.Fatalf("expected one endpoint for %s, got %d in %v", want, urls[want], urls)
+		}
+	}
+	if len(urls) != 3 {
+		t.Fatalf("expected 3 unique endpoints after duplicate repair, got %d: %v", len(urls), urls)
+	}
+	if reconnectIdx < 0 || reconnectReason != "peer_discovery_cycle" {
+		t.Fatalf("expected duplicate repair to schedule reconnect, got idx=%d reason=%q", reconnectIdx, reconnectReason)
+	}
+}
+
 func TestCheckPeerDiscovery_NewURLDiscovered(t *testing.T) {
 	// Connected to g1, g2, g3. DNS returns g1, g2, g3, g4.
 	// More URLs available than connected -- should cycle one endpoint.

--- a/gravity/reresolve_test.go
+++ b/gravity/reresolve_test.go
@@ -381,6 +381,32 @@ func TestReResolveFromDiscoveredSet_RefreshesTLSServerName(t *testing.T) {
 	}
 }
 
+func TestReResolveFromDiscoveredSet_DoesNotPreserveRetargetedSlot(t *testing.T) {
+	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.2:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint1 := &GravityEndpoint{URL: "grpc://10.0.0.1:443", TLSServerName: "gravity-bootstrap.example.com"}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1}, newMockDNSLookup())
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://10.0.0.1:443",
+			"grpc://10.0.0.2:443",
+			"grpc://10.0.0.3:443",
+		}
+	}
+
+	newURL, handled := g.reResolveFromDiscoveredSet(0, "grpc://10.0.0.3:443")
+
+	if !handled {
+		t.Fatal("expected retargeted slot to choose a current discovered URL")
+	}
+	if newURL != "grpc://10.0.0.2:443" {
+		t.Fatalf("expected slot current URL to be returned, got %q", newURL)
+	}
+	if endpoint0.URL != "grpc://10.0.0.2:443" {
+		t.Fatalf("expected endpoint URL to remain on retargeted slot, got %q", endpoint0.URL)
+	}
+}
+
 func TestReResolveFromDiscoveredSet_ClearsTLSServerNameForRawIP(t *testing.T) {
 	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.9:443", TLSServerName: "gravity-bootstrap.example.com"}
 	endpoint1 := &GravityEndpoint{URL: "grpc://10.0.0.1:443", TLSServerName: "gravity-bootstrap.example.com"}

--- a/gravity/reresolve_test.go
+++ b/gravity/reresolve_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/agentuity/go-common/logger"
 )
@@ -314,6 +315,94 @@ func TestReResolveEndpointURL_ConcurrentStaleDirectEndpointsPickUniqueDiscovered
 		if seen[want] != 1 {
 			t.Fatalf("expected exactly one endpoint for %s, got %d in %v", want, seen[want], seen)
 		}
+	}
+}
+
+func TestReResolveFromDiscoveredSet_UsesBoundedResolver(t *testing.T) {
+	endpoint := &GravityEndpoint{
+		URL:           "grpc://10.0.0.9:443",
+		TLSServerName: "gravity-bootstrap.example.com",
+	}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint}, newMockDNSLookup())
+	defer g.cancel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	g.discoveryResolveTimeout = 10 * time.Millisecond
+	g.discoveryResolveFunc = func() []string {
+		close(started)
+		<-release
+		return []string{"grpc://10.0.0.2:443"}
+	}
+	defer close(release)
+
+	begin := time.Now()
+	newURL, handled := g.reResolveFromDiscoveredSet(0, endpoint.URL)
+	elapsed := time.Since(begin)
+
+	if newURL != "" || handled {
+		t.Fatalf("expected timed out resolver to be unhandled, got url=%q handled=%t", newURL, handled)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected bounded resolver timeout, took %s", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected resolver to be called")
+	}
+}
+
+func TestReResolveFromDiscoveredSet_RefreshesTLSServerName(t *testing.T) {
+	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.9:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint1 := &GravityEndpoint{URL: "grpc://ion-a.example.com:443", TLSServerName: "ion-a.example.com"}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1}, newMockDNSLookup())
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://ion-a.example.com:443",
+			"grpc://ion-b.example.com:443",
+		}
+	}
+
+	newURL, handled := g.reResolveFromDiscoveredSet(0, endpoint0.URL)
+
+	if !handled {
+		t.Fatal("expected discovered replacement to be handled")
+	}
+	if newURL != "grpc://ion-b.example.com:443" {
+		t.Fatalf("expected ion-b replacement, got %q", newURL)
+	}
+	if endpoint0.URL != "grpc://ion-b.example.com:443" {
+		t.Fatalf("expected endpoint URL to update, got %q", endpoint0.URL)
+	}
+	if endpoint0.TLSServerName != "ion-b.example.com" {
+		t.Fatalf("expected TLS server name to update, got %q", endpoint0.TLSServerName)
+	}
+}
+
+func TestReResolveFromDiscoveredSet_ClearsTLSServerNameForRawIP(t *testing.T) {
+	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.9:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint1 := &GravityEndpoint{URL: "grpc://10.0.0.1:443", TLSServerName: "gravity-bootstrap.example.com"}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1}, newMockDNSLookup())
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://10.0.0.1:443",
+			"grpc://10.0.0.2:443",
+		}
+	}
+
+	newURL, handled := g.reResolveFromDiscoveredSet(0, endpoint0.URL)
+
+	if !handled {
+		t.Fatal("expected discovered replacement to be handled")
+	}
+	if newURL != "grpc://10.0.0.2:443" {
+		t.Fatalf("expected raw IP replacement, got %q", newURL)
+	}
+	if endpoint0.TLSServerName != "" {
+		t.Fatalf("expected TLS server name to be cleared for raw IP, got %q", endpoint0.TLSServerName)
 	}
 }
 

--- a/gravity/reresolve_test.go
+++ b/gravity/reresolve_test.go
@@ -231,6 +231,92 @@ func TestReResolveEndpointURL_PrefersDiscoveredDirectEndpointsOverBootstrapDNS(t
 	}
 }
 
+func TestReResolveEndpointURL_ConcurrentDiscoveredDirectEndpointsDoNotCollapse(t *testing.T) {
+	mock := newMockDNSLookup()
+	mock.setIPs("gravity-bootstrap.example.com", "10.0.0.2")
+
+	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.3:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint1 := &GravityEndpoint{URL: "grpc://10.0.0.1:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint2 := &GravityEndpoint{URL: "grpc://10.0.0.3:443", TLSServerName: "gravity-bootstrap.example.com"}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1, endpoint2}, mock)
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://10.0.0.1:443",
+			"grpc://10.0.0.2:443",
+			"grpc://10.0.0.3:443",
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, idx := range []int{0, 2} {
+		wg.Add(1)
+		go func(endpointIndex int) {
+			defer wg.Done()
+			if newURL := g.reResolveEndpointURL(endpointIndex, "grpc://10.0.0.3:443"); newURL != "" {
+				t.Errorf("expected endpoint %d to keep retrying discovered direct URL, got %q", endpointIndex, newURL)
+			}
+		}(idx)
+	}
+	wg.Wait()
+
+	for _, idx := range []int{0, 2} {
+		if g.endpoints[idx].URL != "grpc://10.0.0.3:443" {
+			t.Fatalf("expected endpoint %d to remain on direct URL, got %q", idx, g.endpoints[idx].URL)
+		}
+	}
+	if mock.callCount() != 0 {
+		t.Fatalf("expected no bootstrap DNS lookups for discovered direct endpoints, got %d", mock.callCount())
+	}
+}
+
+func TestReResolveEndpointURL_ConcurrentStaleDirectEndpointsPickUniqueDiscoveredURLs(t *testing.T) {
+	endpoint0 := &GravityEndpoint{URL: "grpc://10.0.0.9:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint1 := &GravityEndpoint{URL: "grpc://10.0.0.8:443", TLSServerName: "gravity-bootstrap.example.com"}
+	endpoint2 := &GravityEndpoint{URL: "grpc://10.0.0.1:443", TLSServerName: "gravity-bootstrap.example.com"}
+	g := newReResolveTestClient([]*GravityEndpoint{endpoint0, endpoint1, endpoint2}, newMockDNSLookup())
+	defer g.cancel()
+	g.discoveryResolveFunc = func() []string {
+		return []string{
+			"grpc://10.0.0.1:443",
+			"grpc://10.0.0.2:443",
+			"grpc://10.0.0.3:443",
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, item := range []struct {
+		index int
+		url   string
+	}{
+		{index: 0, url: "grpc://10.0.0.9:443"},
+		{index: 1, url: "grpc://10.0.0.8:443"},
+	} {
+		wg.Add(1)
+		go func(index int, url string) {
+			defer wg.Done()
+			if newURL := g.reResolveEndpointURL(index, url); newURL == "" {
+				t.Errorf("expected stale endpoint %d to choose a discovered replacement", index)
+			}
+		}(item.index, item.url)
+	}
+	wg.Wait()
+
+	seen := make(map[string]int)
+	for _, ep := range g.endpoints {
+		seen[ep.URL]++
+	}
+	for _, want := range []string{
+		"grpc://10.0.0.1:443",
+		"grpc://10.0.0.2:443",
+		"grpc://10.0.0.3:443",
+	} {
+		if seen[want] != 1 {
+			t.Fatalf("expected exactly one endpoint for %s, got %d in %v", want, seen[want], seen)
+		}
+	}
+}
+
 func TestReResolveEndpointURL_HandlesIPv6(t *testing.T) {
 	mock := newMockDNSLookup()
 	mock.setIPs("gravity.example.com", "fd15::2")


### PR DESCRIPTION
## Summary
- preserve discovered direct Gravity endpoints during reconnect so they do not collapse onto another Ion while still present in discovery
- repair full peer sets that contain duplicate endpoint URLs by replacing a duplicate slot with the missing discovered URL
- add regression and race-focused tests for duplicate peer slots and concurrent re-resolve behavior

## Validation
- go test ./gravity
- go test -race ./gravity

Supports agentuity/infra#250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer discovery will repair duplicate endpoints when the pool is full; re-resolution favors direct-discovered coverage and selects distinct replacements.

* **Bug Fixes**
  * Reconnection loop and single-slot reconnect now reliably respect shutdown state and abort cleanly.
  * Stream setup now guards against out-of-bounds connection indices to prevent invalid lookups.

* **Tests**
  * Added tests covering duplicate-endpoint replacement, concurrent re-resolution behaviors, TLS/name refresh, and reconnect shutdown handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/248)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->