### PR TITLE
Improve durable telemetry shutdown draining

### DIFF
--- a/telemetry/log_batcher.go
+++ b/telemetry/log_batcher.go
@@ -102,12 +102,13 @@ type durableLogProcessor struct {
 	cfg      durableLogConfig
 	db       *sql.DB
 
-	emitCh   chan queuedLogRecord
-	wakeCh   chan struct{}
-	flushCh  chan chan struct{}
-	done     chan struct{}
-	wg       sync.WaitGroup
-	replayMu sync.Mutex
+	emitCh     chan queuedLogRecord
+	wakeCh     chan struct{}
+	flushCh    chan chan struct{}
+	done       chan struct{}
+	wg         sync.WaitGroup
+	replayMu   sync.Mutex
+	loopCancel context.CancelFunc
 
 	stopped atomic.Bool
 	dropped atomic.Uint64
@@ -143,18 +144,20 @@ func newDurableLogProcessor(ctx context.Context, exporter sdklog.Exporter, cfg d
 	_, _ = db.ExecContext(ctx, `ALTER TABLE otel_log_queue ADD COLUMN created_at INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.ExecContext(ctx, `UPDATE otel_log_queue SET size_bytes = length(record) WHERE size_bytes = 0`)
 
+	loopCtx, loopCancel := context.WithCancel(context.Background())
 	p := &durableLogProcessor{
-		exporter: exporter,
-		cfg:      cfg,
-		db:       db,
-		emitCh:   make(chan queuedLogRecord, cfg.emitQueueSize),
-		wakeCh:   make(chan struct{}, 1),
-		flushCh:  make(chan chan struct{}),
-		done:     make(chan struct{}),
+		exporter:   exporter,
+		cfg:        cfg,
+		db:         db,
+		emitCh:     make(chan queuedLogRecord, cfg.emitQueueSize),
+		wakeCh:     make(chan struct{}, 1),
+		flushCh:    make(chan chan struct{}),
+		done:       make(chan struct{}),
+		loopCancel: loopCancel,
 	}
 	p.wg.Add(2)
 	go p.writeLoop()
-	go p.exportLoop()
+	go p.exportLoop(loopCtx)
 	return p, nil
 }
 
@@ -217,6 +220,9 @@ func (p *durableLogProcessor) flushWriter(ctx context.Context) error {
 func (p *durableLogProcessor) Shutdown(ctx context.Context) error {
 	if p.stopped.Swap(true) {
 		return nil
+	}
+	if p.loopCancel != nil {
+		p.loopCancel()
 	}
 	close(p.done)
 	done := make(chan struct{})
@@ -352,7 +358,7 @@ func configureDurableQueueDB(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func (p *durableLogProcessor) exportLoop() {
+func (p *durableLogProcessor) exportLoop(loopCtx context.Context) {
 	defer p.wg.Done()
 	backoff := p.cfg.retryInitial
 	timer := time.NewTimer(p.cfg.idleTimeout)
@@ -364,7 +370,7 @@ func (p *durableLogProcessor) exportLoop() {
 		case <-p.wakeCh:
 			resetTimer(timer, p.cfg.idleTimeout)
 		case <-timer.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(loopCtx, 30*time.Second)
 			p.replayMu.Lock()
 			err := p.exportOne(ctx)
 			p.replayMu.Unlock()

--- a/telemetry/metric_batcher.go
+++ b/telemetry/metric_batcher.go
@@ -77,10 +77,11 @@ type durableMetricExporter struct {
 	cfg      durableMetricConfig
 	db       *sql.DB
 
-	wakeCh   chan struct{}
-	done     chan struct{}
-	wg       sync.WaitGroup
-	replayMu sync.Mutex
+	wakeCh     chan struct{}
+	done       chan struct{}
+	wg         sync.WaitGroup
+	replayMu   sync.Mutex
+	loopCancel context.CancelFunc
 
 	stopped atomic.Bool
 }
@@ -119,15 +120,17 @@ func newDurableMetricExporter(ctx context.Context, exporter sdkmetric.Exporter, 
 		return nil, err
 	}
 
+	loopCtx, loopCancel := context.WithCancel(context.Background())
 	e := &durableMetricExporter{
-		exporter: exporter,
-		cfg:      cfg,
-		db:       db,
-		wakeCh:   make(chan struct{}, 1),
-		done:     make(chan struct{}),
+		exporter:   exporter,
+		cfg:        cfg,
+		db:         db,
+		wakeCh:     make(chan struct{}, 1),
+		done:       make(chan struct{}),
+		loopCancel: loopCancel,
 	}
 	e.wg.Add(1)
-	go e.exportLoop()
+	go e.exportLoop(loopCtx)
 	if e.hasRows() {
 		e.wake()
 	}
@@ -207,6 +210,9 @@ func (e *durableMetricExporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {
 		return nil
 	}
+	if e.loopCancel != nil {
+		e.loopCancel()
+	}
 	close(e.done)
 	done := make(chan struct{})
 	go func() {
@@ -251,7 +257,7 @@ func (e *durableMetricExporter) enforceLimits(ctx context.Context) error {
 	return err
 }
 
-func (e *durableMetricExporter) exportLoop() {
+func (e *durableMetricExporter) exportLoop(loopCtx context.Context) {
 	defer e.wg.Done()
 	backoff := e.cfg.retryInitial
 	timer := time.NewTimer(time.Hour)
@@ -263,7 +269,7 @@ func (e *durableMetricExporter) exportLoop() {
 		case <-e.wakeCh:
 			resetTimer(timer, time.Millisecond)
 		case <-timer.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(loopCtx, 30*time.Second)
 			e.replayMu.Lock()
 			err := e.exportBatch(ctx)
 			e.replayMu.Unlock()

--- a/telemetry/metric_batcher_test.go
+++ b/telemetry/metric_batcher_test.go
@@ -242,6 +242,9 @@ func TestDurableMetricExporterCoalescesReplayRows(t *testing.T) {
 }
 
 func stopDurableMetricExporterLoop(t *durableMetricExporter) {
+	if t.loopCancel != nil {
+		t.loopCancel()
+	}
 	close(t.done)
 	t.wg.Wait()
 }

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -42,12 +42,13 @@ type Option func(*config)
 
 // config holds the configuration options for telemetry
 type config struct {
-	dialContext func(ctx context.Context, network, addr string) (net.Conn, error)
-	timeout     time.Duration
-	headers     http.Header
-	logBatch    durableLogConfig
-	metricBatch durableMetricConfig
-	traceBatch  durableTraceConfig
+	dialContext     func(ctx context.Context, network, addr string) (net.Conn, error)
+	timeout         time.Duration
+	shutdownTimeout time.Duration
+	headers         http.Header
+	logBatch        durableLogConfig
+	metricBatch     durableMetricConfig
+	traceBatch      durableTraceConfig
 }
 
 // WithDialContext sets a custom dialer for HTTP connections
@@ -61,6 +62,15 @@ func WithDialContext(dial func(ctx context.Context, network, addr string) (net.C
 func WithTimeout(dur time.Duration) Option {
 	return func(c *config) {
 		c.timeout = dur
+	}
+}
+
+// WithShutdownTimeout sets the per-component timeout used while shutting down
+// telemetry providers and durable queues. Each provider/exporter gets its own
+// budget so a slow OTLP endpoint for logs or metrics cannot starve trace drain.
+func WithShutdownTimeout(dur time.Duration) Option {
+	return func(c *config) {
+		c.shutdownTimeout = dur
 	}
 }
 
@@ -157,6 +167,9 @@ func new(ctx context.Context, oltpServerURL string, authToken string, serviceNam
 	}
 	if cfg.timeout <= 0 {
 		cfg.timeout = 10 * time.Second
+	}
+	if cfg.shutdownTimeout <= 0 {
+		cfg.shutdownTimeout = cfg.timeout + time.Second
 	}
 	// parse oltpURL
 	oltpURL, err := url.Parse(oltpServerURL)
@@ -329,21 +342,31 @@ func new(ctx context.Context, oltpServerURL string, authToken string, serviceNam
 	otel.SetTextMapPropagator(tc)
 
 	shutdown := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout+time.Second)
-		defer cancel()
-		logProvider.Shutdown(ctx)
-		meterProvider.Shutdown(ctx)
-		tracerProvider.Shutdown(ctx)
-		durableTraceExporter.Shutdown(ctx)
-		durableMetricExporter.Shutdown(ctx)
-		traceExporter.Shutdown(ctx)
-		logExporter.Shutdown(ctx)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, logProvider.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, meterProvider.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, tracerProvider.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, durableTraceExporter.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, durableMetricExporter.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, traceExporter.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, logExporter.Shutdown)
 	}
 
 	return ctx,
 		logger.NewOtelLogger(otelsLogger, logger.LevelTrace),
 		shutdown,
 		nil
+}
+
+func shutdownTelemetryComponent(timeout time.Duration, shutdown func(context.Context) error) {
+	if shutdown == nil {
+		return
+	}
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_ = shutdown(ctx)
 }
 
 func New(ctx context.Context, serviceName string, telemetrySecret string, telemetryURL string, consoleLogger logger.Logger, opts ...Option) (context.Context, logger.Logger, func(), error) {

--- a/telemetry/otel_test.go
+++ b/telemetry/otel_test.go
@@ -103,6 +103,39 @@ func TestNewWithInvalidURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "error parsing oltpServerURL")
 }
 
+func TestShutdownTelemetryComponentUsesIndependentTimeouts(t *testing.T) {
+	const timeout = 25 * time.Millisecond
+
+	firstStarted := make(chan struct{})
+	firstDone := make(chan struct{})
+	shutdownTelemetryComponent(timeout, func(ctx context.Context) error {
+		close(firstStarted)
+		<-ctx.Done()
+		close(firstDone)
+		return ctx.Err()
+	})
+
+	select {
+	case <-firstStarted:
+	default:
+		t.Fatal("expected first shutdown function to start")
+	}
+	select {
+	case <-firstDone:
+	default:
+		t.Fatal("expected first shutdown function to stop at its own timeout")
+	}
+
+	secondCalled := false
+	shutdownTelemetryComponent(timeout, func(ctx context.Context) error {
+		secondCalled = true
+		return nil
+	})
+	if !secondCalled {
+		t.Fatal("expected later shutdown functions to get their own timeout budget")
+	}
+}
+
 func TestTelemetrySendsLogsTracesAndMetrics(t *testing.T) {
 	var mu sync.Mutex
 	hits := map[string]int{}

--- a/telemetry/trace_batcher.go
+++ b/telemetry/trace_batcher.go
@@ -76,9 +76,10 @@ type durableTraceExporter struct {
 	cfg      durableTraceConfig
 	db       *sql.DB
 
-	wakeCh chan struct{}
-	done   chan struct{}
-	wg     sync.WaitGroup
+	wakeCh     chan struct{}
+	done       chan struct{}
+	wg         sync.WaitGroup
+	loopCancel context.CancelFunc
 
 	stopped atomic.Bool
 }
@@ -113,15 +114,17 @@ func newDurableTraceExporter(ctx context.Context, exporter sdktrace.SpanExporter
 	_, _ = db.ExecContext(ctx, `ALTER TABLE otel_trace_queue ADD COLUMN created_at INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.ExecContext(ctx, `UPDATE otel_trace_queue SET size_bytes = length(payload) WHERE size_bytes = 0`)
 
+	loopCtx, loopCancel := context.WithCancel(context.Background())
 	e := &durableTraceExporter{
-		exporter: exporter,
-		cfg:      cfg,
-		db:       db,
-		wakeCh:   make(chan struct{}, 1),
-		done:     make(chan struct{}),
+		exporter:   exporter,
+		cfg:        cfg,
+		db:         db,
+		wakeCh:     make(chan struct{}, 1),
+		done:       make(chan struct{}),
+		loopCancel: loopCancel,
 	}
 	e.wg.Add(1)
-	go e.exportLoop()
+	go e.exportLoop(loopCtx)
 	if e.hasRows() {
 		e.wake()
 	}
@@ -150,6 +153,9 @@ func (e *durableTraceExporter) ExportSpans(ctx context.Context, spans []sdktrace
 func (e *durableTraceExporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {
 		return nil
+	}
+	if e.loopCancel != nil {
+		e.loopCancel()
 	}
 	close(e.done)
 	done := make(chan struct{})
@@ -195,7 +201,7 @@ func (e *durableTraceExporter) enforceLimits(ctx context.Context) error {
 	return nil
 }
 
-func (e *durableTraceExporter) exportLoop() {
+func (e *durableTraceExporter) exportLoop(loopCtx context.Context) {
 	defer e.wg.Done()
 	backoff := e.cfg.retryInitial
 	timer := time.NewTimer(time.Hour)
@@ -207,7 +213,7 @@ func (e *durableTraceExporter) exportLoop() {
 		case <-e.wakeCh:
 			resetTimer(timer, time.Millisecond)
 		case <-timer.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(loopCtx, 30*time.Second)
 			err := e.exportBatch(ctx)
 			cancel()
 			if err != nil {

--- a/telemetry/trace_batcher_test.go
+++ b/telemetry/trace_batcher_test.go
@@ -214,6 +214,9 @@ func TestDurableTraceExporterCoalescesReplayRows(t *testing.T) {
 }
 
 func stopDurableTraceExporterLoop(e *durableTraceExporter) {
+	if e.loopCancel != nil {
+		e.loopCancel()
+	}
 	close(e.done)
 	e.wg.Wait()
 }


### PR DESCRIPTION
## Summary
- add `telemetry.WithShutdownTimeout` to configure shutdown drain budget separately from HTTP export timeout
- give each telemetry provider/exporter an independent shutdown context so logs/metrics cannot consume the trace drain budget
- cancel durable log/trace/metric replay loops on shutdown so a stale in-flight 30s background export does not block final queue drain

## Context
While validating hadron with go-common v1.0.235, `systemctl stop hadron` timed out and SIGKILLed the process while OTLP trace exports were hitting context deadlines. Durable sqlite replay recovered on restart, but shutdown left `otel_trace_queue` rows behind. This change improves graceful shutdown behavior while preserving durable replay as the fallback when OTLP remains unavailable.

## Validation
- `go test ./telemetry`
- `go test ./...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-component shutdown timeout option for telemetry components, allowing independent timeout control instead of a single global deadline.

* **Bug Fixes**
  * Improved graceful shutdown behavior for telemetry export loops by implementing proper context cancellation, ensuring in-flight batch processing can be properly stopped during shutdown.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->