### PR TITLE
Fix telemetry exporter startup blocking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,8 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.7.3 // indirect
+	github.com/redis/go-redis/extra/redisotel/v9 v9.7.3 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.7.3 h1:1AXQZkJkFxGV3f78mSnUI70l0orO6FHnYoSmBos8SZM=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.7.3/go.mod h1:OgkpkwJYex1oyVAabK+VhVUKhUXw8uZUfewJYH1wG90=
+github.com/redis/go-redis/extra/redisotel/v9 v9.7.3 h1:ICBA9xYh+SmZqMfBtjKpp1ohi/V5R1TEZglLZc8IxTc=
+github.com/redis/go-redis/extra/redisotel/v9 v9.7.3/go.mod h1:DMzxd0CDyZ9VFw9sEPIVpIgKTAaubfGuaPQSUaS7/fo=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/telemetry/log_batcher.go
+++ b/telemetry/log_batcher.go
@@ -425,6 +425,7 @@ func (p *durableLogProcessor) exportOne(ctx context.Context) error {
 		var data []byte
 		var size int
 		if err := rows.Scan(&id, &data, &size); err != nil {
+			_ = rows.Close()
 			return err
 		}
 		if len(records) > 0 && total+size > p.cfg.maxBytes {

--- a/telemetry/log_batcher.go
+++ b/telemetry/log_batcher.go
@@ -416,7 +416,6 @@ func (p *durableLogProcessor) exportOne(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	var ids []int64
 	var records []sdklog.Record
@@ -441,6 +440,10 @@ func (p *durableLogProcessor) exportOne(ctx context.Context) error {
 		total += size
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
 		return err
 	}
 	if len(ids) == 0 {

--- a/telemetry/log_batcher_test.go
+++ b/telemetry/log_batcher_test.go
@@ -263,6 +263,79 @@ func TestDurableLogProcessorCoalescesReplayRows(t *testing.T) {
 	assertQueueEmpty(t, p.db, "otel_log_queue")
 }
 
+type blockingLogExporter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *blockingLogExporter) Export(ctx context.Context, _ []sdklog.Record) error {
+	e.once.Do(func() {
+		close(e.started)
+	})
+	select {
+	case <-e.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (e *blockingLogExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *blockingLogExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func TestDurableLogProcessorDoesNotHoldDBConnectionDuringReplayExport(t *testing.T) {
+	exporter := &blockingLogExporter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	p, err := newDurableLogProcessor(context.Background(), exporter, durableLogConfig{
+		path:           filepath.Join(t.TempDir(), "logs.db"),
+		idleTimeout:    time.Hour,
+		emitQueueSize:  10,
+		writeBatchSize: 10,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.insert([]queuedLogRecord{mustQueuedLogRecord(t, testLogRecord("blocked replay"))}))
+	flushDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		flushDone <- p.ForceFlush(ctx)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-exporter.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	insertDone := make(chan error, 1)
+	go func() {
+		insertDone <- p.insert([]queuedLogRecord{mustQueuedLogRecord(t, testLogRecord("while replaying"))})
+	}()
+	select {
+	case err := <-insertDone:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("log insert blocked while replay export was waiting")
+	}
+
+	close(exporter.release)
+	require.NoError(t, <-flushDone)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	require.NoError(t, p.Shutdown(shutdownCtx))
+}
+
 func ptrRecord(r sdklog.Record) *sdklog.Record {
 	return &r
 }

--- a/telemetry/metric_batcher.go
+++ b/telemetry/metric_batcher.go
@@ -315,7 +315,6 @@ func (e *durableMetricExporter) exportBatch(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	var ids []int64
 	var resourceMetrics []metricdata.ResourceMetrics
@@ -340,6 +339,10 @@ func (e *durableMetricExporter) exportBatch(ctx context.Context) error {
 		totalBytes += size
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
 		return err
 	}
 	if len(ids) == 0 {

--- a/telemetry/metric_batcher.go
+++ b/telemetry/metric_batcher.go
@@ -324,6 +324,7 @@ func (e *durableMetricExporter) exportBatch(ctx context.Context) error {
 		var payload []byte
 		var size int
 		if err := rows.Scan(&id, &payload, &size); err != nil {
+			_ = rows.Close()
 			return err
 		}
 		if len(ids) > 0 && totalBytes+size > e.cfg.replayMaxBytes {

--- a/telemetry/metric_batcher_test.go
+++ b/telemetry/metric_batcher_test.go
@@ -241,6 +241,72 @@ func TestDurableMetricExporterCoalescesReplayRows(t *testing.T) {
 	assertQueueEmpty(t, e.db, "otel_metric_queue")
 }
 
+type blockingMetricExporter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *blockingMetricExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+func (e *blockingMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(kind)
+}
+
+func (e *blockingMetricExporter) Export(ctx context.Context, _ *metricdata.ResourceMetrics) error {
+	e.once.Do(func() {
+		close(e.started)
+	})
+	select {
+	case <-e.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (e *blockingMetricExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (e *blockingMetricExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func TestDurableMetricExporterDoesNotHoldDBConnectionDuringReplayExport(t *testing.T) {
+	exporter := &blockingMetricExporter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	e, err := newDurableMetricExporter(context.Background(), exporter, durableMetricConfig{
+		path: filepath.Join(t.TempDir(), "metrics.db"),
+	})
+	require.NoError(t, err)
+
+	rm := testResourceMetrics()
+	require.NoError(t, e.Export(context.Background(), &rm))
+	require.Eventually(t, func() bool {
+		select {
+		case <-exporter.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	rm = testResourceMetrics()
+	require.NoError(t, e.Export(ctx, &rm))
+
+	close(exporter.release)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	require.NoError(t, e.Shutdown(shutdownCtx))
+}
+
 func stopDurableMetricExporterLoop(t *durableMetricExporter) {
 	if t.loopCancel != nil {
 		t.loopCancel()

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -307,7 +307,7 @@ func new(ctx context.Context, oltpServerURL string, authToken string, serviceNam
 
 	// Create trace provider
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSyncer(durableTraceExporter),
+		sdktrace.WithBatcher(durableTraceExporter),
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(tracerProvider)

--- a/telemetry/otel_test.go
+++ b/telemetry/otel_test.go
@@ -321,5 +321,4 @@ func TestBatchSpanProcessorDoesNotBlockWhenDurableTraceQueueIsBusy(t *testing.T)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	require.NoError(t, provider.Shutdown(ctx))
-	require.NoError(t, durable.Shutdown(ctx))
 }

--- a/telemetry/otel_test.go
+++ b/telemetry/otel_test.go
@@ -11,10 +11,14 @@ import (
 	"time"
 
 	"github.com/agentuity/go-common/logger"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/extra/redisotel/v9"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func getTestValues() (string, string, string) {
@@ -188,4 +192,134 @@ func TestTelemetrySendsLogsTracesAndMetrics(t *testing.T) {
 		defer mu.Unlock()
 		return hits["/v1/logs"] > 0 && hits["/v1/traces"] > 0 && hits["/v1/metrics"] > 0
 	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestSlowTelemetryExporterDoesNotBlockInstrumentedRedisPing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		http.Error(w, "tableflip old process still exiting", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	mr := miniredis.RunT(t)
+
+	for _, tt := range []struct {
+		name       string
+		seedReplay bool
+	}{
+		{name: "empty queues"},
+		{name: "active replay", seedReplay: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ctx, log, shutdown, err := NewWithAPIKey(
+				ctx,
+				"test-service",
+				server.URL,
+				"api-key",
+				nil,
+				WithTimeout(50*time.Millisecond),
+				WithShutdownTimeout(50*time.Millisecond),
+				WithLogBatchPath(filepath.Join(tmp, "logs.db")),
+				WithMetricBatchPath(filepath.Join(tmp, "metrics.db")),
+				WithTraceBatchPath(filepath.Join(tmp, "traces.db")),
+				WithLogBatchIdleTimeout(10*time.Millisecond),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, ctx)
+			require.NotNil(t, log)
+			t.Cleanup(shutdown)
+
+			if tt.seedReplay {
+				log.Info("seed log replay")
+
+				spanCtx, span := otel.Tracer("telemetry-redis-repro").Start(ctx, "seed-span")
+				span.End()
+
+				counter, err := otel.Meter("telemetry-redis-repro").Int64Counter("seed.counter")
+				require.NoError(t, err)
+				counter.Add(spanCtx, 1)
+			}
+
+			client := redis.NewClient(&redis.Options{
+				Addr:         mr.Addr(),
+				DialTimeout:  50 * time.Millisecond,
+				ReadTimeout:  50 * time.Millisecond,
+				WriteTimeout: 50 * time.Millisecond,
+				PoolTimeout:  50 * time.Millisecond,
+			})
+			t.Cleanup(func() {
+				require.NoError(t, client.Close())
+			})
+
+			require.NoError(t, redisotel.InstrumentTracing(client))
+			require.NoError(t, redisotel.InstrumentMetrics(client))
+
+			pingCtx, pingCancel := context.WithTimeout(context.Background(), time.Second)
+			defer pingCancel()
+
+			start := time.Now()
+			require.NoError(t, client.Ping(pingCtx).Err())
+			require.Less(t, time.Since(start), 250*time.Millisecond)
+		})
+	}
+}
+
+type blockingSpanExporter struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *blockingSpanExporter) ExportSpans(ctx context.Context, _ []sdktrace.ReadOnlySpan) error {
+	e.once.Do(func() {
+		close(e.started)
+	})
+	select {
+	case <-e.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (e *blockingSpanExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func TestBatchSpanProcessorDoesNotBlockWhenDurableTraceQueueIsBusy(t *testing.T) {
+	exporter := &blockingSpanExporter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	durable, err := newDurableTraceExporter(context.Background(), exporter, durableTraceConfig{
+		path: filepath.Join(t.TempDir(), "traces.db"),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, durable.ExportSpans(context.Background(), []sdktrace.ReadOnlySpan{testReadOnlySpan()}))
+	require.Eventually(t, func() bool {
+		select {
+		case <-exporter.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	provider := sdktrace.NewTracerProvider(sdktrace.WithBatcher(durable))
+
+	start := time.Now()
+	_, span := provider.Tracer("telemetry-test").Start(context.Background(), "span")
+	span.End()
+	require.Less(t, time.Since(start), 100*time.Millisecond)
+
+	close(exporter.release)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, provider.Shutdown(ctx))
+	require.NoError(t, durable.Shutdown(ctx))
 }

--- a/telemetry/trace_batcher.go
+++ b/telemetry/trace_batcher.go
@@ -256,7 +256,6 @@ func (e *durableTraceExporter) exportBatch(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	var ids []int64
 	var spans []sdktrace.ReadOnlySpan
@@ -281,6 +280,10 @@ func (e *durableTraceExporter) exportBatch(ctx context.Context) error {
 		totalBytes += size
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
 		return err
 	}
 	if len(ids) == 0 {

--- a/telemetry/trace_batcher.go
+++ b/telemetry/trace_batcher.go
@@ -265,6 +265,7 @@ func (e *durableTraceExporter) exportBatch(ctx context.Context) error {
 		var payload []byte
 		var size int
 		if err := rows.Scan(&id, &payload, &size); err != nil {
+			_ = rows.Close()
 			return err
 		}
 		if len(ids) > 0 && totalBytes+size > e.cfg.replayMaxBytes {

--- a/telemetry/trace_batcher_test.go
+++ b/telemetry/trace_batcher_test.go
@@ -213,6 +213,36 @@ func TestDurableTraceExporterCoalescesReplayRows(t *testing.T) {
 	assertQueueEmpty(t, e.db, "otel_trace_queue")
 }
 
+func TestDurableTraceExporterDoesNotHoldDBConnectionDuringReplayExport(t *testing.T) {
+	exporter := &blockingSpanExporter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	e, err := newDurableTraceExporter(context.Background(), exporter, durableTraceConfig{
+		path: filepath.Join(t.TempDir(), "traces.db"),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, e.ExportSpans(context.Background(), []sdktrace.ReadOnlySpan{testReadOnlySpan()}))
+	require.Eventually(t, func() bool {
+		select {
+		case <-exporter.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	require.NoError(t, e.ExportSpans(ctx, []sdktrace.ReadOnlySpan{testReadOnlySpan()}))
+
+	close(exporter.release)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	require.NoError(t, e.Shutdown(shutdownCtx))
+}
+
 func stopDurableTraceExporterLoop(e *durableTraceExporter) {
 	if e.loopCancel != nil {
 		e.loopCancel()


### PR DESCRIPTION
## Summary

- switch durable tracing from synchronous span export to the OpenTelemetry batch span processor
- close durable telemetry replay query rows before calling remote OTLP exporters
- add regression tests covering Redis instrumentation startup and durable replay DB connection contention

## Why

Ion startup could block inside instrumented Redis calls when span end synchronously entered the durable trace exporter. During replay, the durable exporters also held the single SQLite connection open while waiting on the remote exporter, which could block new writes behind a slow or unavailable OTLP endpoint.

## Validation

- `go test ./telemetry -count=1`
- `go test ./...`
- live-tested in us-central with an ion binary built via `replace github.com/agentuity/go-common => /Users/jhaynie/code/agentuity/go-common`; Redis startup completed and the ion reached convergence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry export resource cleanup to prevent DB connection blocking during replay/export.

* **New Features**
  * Switched trace processing to a batched exporter for more efficient trace handling.

* **Tests**
  * Added concurrency and backpressure tests ensuring telemetry exports (traces/metrics/logs) don’t stall application operations.

* **Chores**
  * Updated telemetry-related dependencies and instrumentation for Redis and OpenTelemetry.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->