### PR TITLE
Add log-only telemetry forwarder

### DIFF
--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -430,7 +430,12 @@ func NewLogForwarderWithAPIKey(ctx context.Context, serviceName string, telemetr
 	kvs = append(kvs, cfg.resourceAttrs...)
 	res, err := resource.New(
 		ctx,
+		resource.WithFromEnv(),
 		resource.WithTelemetrySDK(),
+		resource.WithProcess(),
+		resource.WithOS(),
+		resource.WithContainer(),
+		resource.WithHost(),
 		resource.WithAttributes(kvs...),
 	)
 	if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -46,6 +46,7 @@ type config struct {
 	timeout         time.Duration
 	shutdownTimeout time.Duration
 	headers         http.Header
+	resourceAttrs   []attribute.KeyValue
 	logBatch        durableLogConfig
 	metricBatch     durableMetricConfig
 	traceBatch      durableTraceConfig
@@ -78,6 +79,12 @@ func WithShutdownTimeout(dur time.Duration) Option {
 func WithHeaders(headers http.Header) Option {
 	return func(c *config) {
 		c.headers = headers
+	}
+}
+
+func WithResourceAttributes(attrs ...attribute.KeyValue) Option {
+	return func(c *config) {
+		c.resourceAttrs = append(c.resourceAttrs, attrs...)
 	}
 }
 
@@ -198,6 +205,7 @@ func new(ctx context.Context, oltpServerURL string, authToken string, serviceNam
 	}
 
 	kvs = append(kvs, semconv.ServiceName(serviceName))
+	kvs = append(kvs, cfg.resourceAttrs...)
 
 	res, err := resource.New(
 		ctx,
@@ -393,6 +401,101 @@ func NewWithAPIKey(ctx context.Context, serviceName string, telemetryURL string,
 		return ctx2, olog, shutdownMetrics, nil
 	}
 	return ctx2, olog.Stack(consoleLogger), shutdownMetrics, nil
+}
+
+// NewLogForwarderWithAPIKey creates an OTLP log-only logger backed by the durable
+// local log queue. It does not mutate global OpenTelemetry providers, so callers
+// can safely create multiple forwarders with different resource attributes and
+// durable queue paths in the same process.
+func NewLogForwarderWithAPIKey(ctx context.Context, serviceName string, telemetryURL string, telemetryAPIKey string, consoleLogger logger.Logger, opts ...Option) (logger.Logger, func(), error) {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.timeout <= 0 {
+		cfg.timeout = 10 * time.Second
+	}
+	if cfg.shutdownTimeout <= 0 {
+		cfg.shutdownTimeout = cfg.timeout + time.Second
+	}
+
+	oltpURL, err := url.Parse(telemetryURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing oltpServerURL: %w", err)
+	}
+	oltpURL.Path = "/v1/logs"
+	logURL := oltpURL.String()
+
+	kvs := []attribute.KeyValue{semconv.ServiceName(serviceName)}
+	kvs = append(kvs, cfg.resourceAttrs...)
+	res, err := resource.New(
+		ctx,
+		resource.WithTelemetrySDK(),
+		resource.WithAttributes(kvs...),
+	)
+	if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {
+		fmt.Println(err)
+	} else if err != nil {
+		return nil, nil, fmt.Errorf("error creating resource: %w", err)
+	}
+
+	headers := make(map[string]string)
+	for k, v := range cfg.headers {
+		headers[k] = strings.Join(v, ",")
+	}
+	if telemetryAPIKey != "" {
+		headers["Authorization"] = "Bearer " + telemetryAPIKey
+	}
+
+	var httpClient *http.Client
+	if cfg.dialContext != nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = cfg.dialContext
+		transport.ForceAttemptHTTP2 = true
+		httpClient = &http.Client{
+			Transport: transport,
+			Timeout:   cfg.timeout,
+		}
+	}
+
+	logExporterOpts := []otlploghttp.Option{
+		otlploghttp.WithEndpointURL(logURL),
+		otlploghttp.WithHeaders(headers),
+		otlploghttp.WithTimeout(cfg.timeout),
+		otlploghttp.WithCompression(otlploghttp.GzipCompression),
+	}
+	if oltpURL.Scheme == "http" {
+		logExporterOpts = append(logExporterOpts, otlploghttp.WithInsecure())
+	}
+	if httpClient != nil {
+		logExporterOpts = append(logExporterOpts, otlploghttp.WithHTTPClient(httpClient))
+	}
+	logExporter, err := otlploghttp.New(ctx, logExporterOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating log exporter: %w", err)
+	}
+
+	logProcessor, err := newDurableLogProcessor(ctx, logExporter, cfg.logBatch)
+	if err != nil {
+		logExporter.Shutdown(ctx)
+		return nil, nil, fmt.Errorf("error creating log processor: %w", err)
+	}
+
+	logProvider := sdklog.NewLoggerProvider(
+		sdklog.WithResource(res),
+		sdklog.WithProcessor(logProcessor),
+	)
+	otelLogger := logger.NewOtelLogger(logProvider.Logger(serviceName), logger.LevelTrace)
+	if consoleLogger != nil {
+		otelLogger = otelLogger.Stack(consoleLogger)
+	}
+
+	shutdown := func() {
+		shutdownTelemetryComponent(cfg.shutdownTimeout, logProvider.Shutdown)
+		shutdownTelemetryComponent(cfg.shutdownTimeout, logExporter.Shutdown)
+	}
+
+	return otelLogger, shutdown, nil
 }
 
 func StartSpan(ctx context.Context, logger logger.Logger, tracer trace.Tracer, spanName string, opts ...trace.SpanStartOption) (context.Context, logger.Logger, trace.Span) {

--- a/telemetry/otel_test.go
+++ b/telemetry/otel_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
@@ -192,6 +193,55 @@ func TestTelemetrySendsLogsTracesAndMetrics(t *testing.T) {
 		defer mu.Unlock()
 		return hits["/v1/logs"] > 0 && hits["/v1/traces"] > 0 && hits["/v1/metrics"] > 0
 	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestNewLogForwarderWithAPIKeySendsOnlyLogs(t *testing.T) {
+	var mu sync.Mutex
+	hits := map[string]int{}
+	authHeaders := map[string]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits[r.URL.Path]++
+		authHeaders[r.URL.Path] = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	ctx := context.Background()
+	log, shutdown, err := NewLogForwarderWithAPIKey(
+		ctx,
+		"container-log-forwarder",
+		server.URL,
+		"sk_test",
+		nil,
+		WithLogBatchPath(filepath.Join(tmp, "container-1-logs.db")),
+		WithLogBatchIdleTimeout(10*time.Millisecond),
+		WithResourceAttributes(
+			attribute.String("@agentuity/orgId", "org_123"),
+			attribute.String("@agentuity/projectId", "proj_123"),
+			attribute.String("@agentuity/deploymentId", "dep_123"),
+		),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, log)
+	require.NotNil(t, shutdown)
+
+	log.Info("hello from container")
+	shutdown()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits["/v1/logs"] > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "Bearer sk_test", authHeaders["/v1/logs"])
+	assert.Zero(t, hits["/v1/traces"])
+	assert.Zero(t, hits["/v1/metrics"])
 }
 
 func TestSlowTelemetryExporterDoesNotBlockInstrumentedRedisPing(t *testing.T) {

--- a/telemetry/otel_test.go
+++ b/telemetry/otel_test.go
@@ -238,10 +238,14 @@ func TestNewLogForwarderWithAPIKeySendsOnlyLogs(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 
 	mu.Lock()
-	defer mu.Unlock()
 	assert.Equal(t, "Bearer sk_test", authHeaders["/v1/logs"])
-	assert.Zero(t, hits["/v1/traces"])
-	assert.Zero(t, hits["/v1/metrics"])
+	mu.Unlock()
+
+	require.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits["/v1/traces"] > 0 || hits["/v1/metrics"] > 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestSlowTelemetryExporterDoesNotBlockInstrumentedRedisPing(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a log-only OTLP forwarder constructor that does not mutate global OpenTelemetry providers
- allow explicit resource attributes for per-container/per-deployment log forwarding
- reuse durable log batching with caller-provided SQLite batch paths

## Test
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for injecting custom OpenTelemetry resource attributes into telemetry configuration.
  * Added a log-only forwarder with API-key authentication, configurable headers and HTTP dialing, and durable log batching with a safe shutdown.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/252)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->