### PR TITLE
Handle nil gravity session clients during reconnect

### DIFF
--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -178,6 +178,34 @@ func TestEstablishControlStreams_PartialFailure(t *testing.T) {
 	}
 }
 
+func TestEstablishControlStreams_MultiEndpointSkipsNilClients(t *testing.T) {
+	g := newResilienceTestClient(t, 4, true)
+	g.sessionClients = []pb.GravitySessionServiceClient{
+		&mockSessionClient{},
+		nil,
+		&mockSessionClient{},
+		nil,
+	}
+
+	err := g.establishControlStreams()
+	if err != nil {
+		t.Fatalf("expected partial success with nil clients skipped, got error: %v", err)
+	}
+
+	if got := countNonNilControlStreams(g); got != 2 {
+		t.Fatalf("expected 2 established control streams, got %d", got)
+	}
+
+	for _, idx := range []int{1, 3} {
+		if g.streamManager.controlStreams[idx] != nil {
+			t.Fatalf("expected nil client endpoint %d control stream=nil", idx)
+		}
+		if !g.endpointReconnecting[idx].Load() {
+			t.Fatalf("expected nil client endpoint %d reconnecting=true", idx)
+		}
+	}
+}
+
 func TestEstablishControlStreams_AllFail(t *testing.T) {
 	g := newResilienceTestClient(t, 3, true)
 	g.sessionClients = []pb.GravitySessionServiceClient{
@@ -205,6 +233,22 @@ func TestEstablishControlStreams_SingleEndpointPreservesOriginalBehavior(t *test
 	err := g.establishControlStreams()
 	if err == nil {
 		t.Fatalf("expected error in single-endpoint mode")
+	}
+	if g.endpointReconnecting[0].Load() {
+		t.Fatalf("expected single-endpoint reconnecting flag to remain false")
+	}
+}
+
+func TestEstablishControlStreams_SingleEndpointNilClientReturnsError(t *testing.T) {
+	g := newResilienceTestClient(t, 1, false)
+	g.sessionClients = []pb.GravitySessionServiceClient{nil}
+
+	err := g.establishControlStreams()
+	if err == nil {
+		t.Fatalf("expected error for nil single-endpoint session client")
+	}
+	if !strings.Contains(err.Error(), "session client 0 is not available") {
+		t.Fatalf("expected nil session client error, got: %v", err)
 	}
 	if g.endpointReconnecting[0].Load() {
 		t.Fatalf("expected single-endpoint reconnecting flag to remain false")

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -2193,6 +2193,9 @@ func (g *GravityClient) establishControlStreams() error {
 				i, numConns, len(g.streamManager.contexts), len(g.streamManager.controlStreams))
 			break
 		}
+		if client == nil {
+			return fmt.Errorf("session client %d is not available", i)
+		}
 		g.logger.Debug("establishing control stream %d/%d", i+1, len(g.connections))
 		ctx, cancel := context.WithCancel(g.ctx)
 		g.streamManager.contexts[i] = ctx
@@ -2236,6 +2239,10 @@ func (g *GravityClient) establishControlStreamsMulti() error {
 	results := make(chan establishResult, n)
 
 	for i, client := range g.sessionClients {
+		if client == nil {
+			results <- establishResult{index: i, err: fmt.Errorf("session client %d is not available", i)}
+			continue
+		}
 		go func(idx int, c pb.GravitySessionServiceClient) {
 			ctx, cancel := context.WithCancel(g.ctx)
 			stream, err := c.EstablishSession(ctx, grpc.UseCompressor(grpcgzip.Name))
@@ -2254,7 +2261,9 @@ func (g *GravityClient) establishControlStreamsMulti() error {
 			if !isContextCanceled(g.ctx, result.err) {
 				g.logger.Debug("control stream %d failed: %v", result.index+1, result.err)
 			}
-			result.cancel()
+			if result.cancel != nil {
+				result.cancel()
+			}
 			failed = append(failed, result.index)
 			lastErr = result.err
 			continue


### PR DESCRIPTION
## Summary
- guard single-endpoint control stream setup against nil session clients so reconnect returns an error instead of panicking
- treat nil multi-endpoint session clients as failed endpoints so healthy peers can continue and failed slots reconnect
- add regression coverage for nil session clients in both modes

Fixes agentuity/infra#362.

## Validation
- go test ./gravity -run 'TestEstablishControlStreams|TestEstablishTunnelStreams_SkipsNilClients'\n- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unavailable session clients with clearer error messages.
  * Enhanced multi-endpoint resilience by properly handling unavailable endpoints without creating unnecessary connections.
  * Fixed potential resource cleanup issues during control stream establishment failures.

* **Tests**
  * Added comprehensive test coverage for control stream resilience scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->