### PR TITLE
Fix unzip file descriptor leak

### DIFF
--- a/sys/io.go
+++ b/sys/io.go
@@ -385,93 +385,96 @@ func Unzip(src, dest string, flatten bool) error {
 	defer r.Close()
 
 	for _, f := range r.File {
-		// Check for directory traversal attacks by examining path components
-		// Split the path and check each component
-		pathParts := strings.Split(filepath.ToSlash(f.Name), "/")
-		for _, part := range pathParts {
-			// Block path components that could be used for directory traversal
-			// ".." is obvious, but also block pure dot sequences (3+ dots) that might be interpreted as ".."
-			if part == ".." || (len(part) >= 3 && strings.Trim(part, ".") == "") {
-				return fmt.Errorf("invalid file path: %s", f.Name)
-			}
-		}
-
-		rc, err := f.Open()
-		if err != nil {
+		if err := unzipFile(f, dest, flatten); err != nil {
 			return err
-		}
-		defer rc.Close()
-
-		if flatten {
-			f.Name = filepath.Base(f.Name)
-		}
-
-		// Validate file name before path construction to catch absolute paths and other attacks
-		if filepath.IsAbs(f.Name) {
-			return fmt.Errorf("invalid file path, absolute path not allowed: %s", f.Name)
-		}
-
-		// Check for Windows-style absolute paths and UNC paths (platform-independent)
-		if len(f.Name) >= 3 && f.Name[1] == ':' && (f.Name[2] == '\\' || f.Name[2] == '/') {
-			return fmt.Errorf("invalid file path, Windows drive path not allowed: %s", f.Name)
-		}
-		if strings.HasPrefix(f.Name, "\\\\") {
-			return fmt.Errorf("invalid file path, UNC path not allowed: %s", f.Name)
-		}
-
-		fpath := filepath.Join(dest, f.Name)
-
-		// Canonicalize paths and validate against directory traversal
-		destRoot := filepath.Clean(dest)
-		if !strings.HasSuffix(destRoot, string(os.PathSeparator)) {
-			destRoot += string(os.PathSeparator)
-		}
-		cleanedFpath := filepath.Clean(fpath)
-
-		// Ensure the cleaned file path is within the destination directory
-		if !strings.HasPrefix(cleanedFpath+string(os.PathSeparator), destRoot) {
-			return fmt.Errorf("invalid file path, outside destination directory: %s", f.Name)
-		}
-
-		if f.FileInfo().IsDir() && !flatten {
-			os.MkdirAll(fpath, os.ModePerm)
-		} else {
-			var fdir string
-			if lastIndex := strings.LastIndex(fpath, string(os.PathSeparator)); lastIndex > -1 {
-				fdir = fpath[:lastIndex]
-			}
-
-			err = os.MkdirAll(fdir, os.ModePerm)
-			if err != nil {
-				return err
-			}
-
-			// Zip archives created on Windows may store zero or incorrect Unix
-			// permission bits, causing EACCES errors when the extracted files
-			// are read on Linux.  Ensure the owner-read bit is always present
-			// while preserving any existing execute bits.
-			mode := f.Mode()
-			if mode.Perm() == 0 {
-				// Entirely missing permissions — set sensible default but
-				// keep any execute bits from the original mode.
-				mode = (mode & 0o111) | 0o600
-			} else if mode&0o400 == 0 {
-				// Has some bits but owner-read is missing — add it.
-				mode = mode | 0o400
-			}
-
-			f, err := os.OpenFile(
-				fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			_, err = io.Copy(f, rc)
-			if err != nil {
-				return err
-			}
 		}
 	}
 	return nil
+}
+
+func unzipFile(f *zip.File, dest string, flatten bool) error {
+	name := f.Name
+
+	// Check for directory traversal attacks by examining path components
+	// Split the path and check each component
+	pathParts := strings.Split(filepath.ToSlash(name), "/")
+	for _, part := range pathParts {
+		// Block path components that could be used for directory traversal
+		// ".." is obvious, but also block pure dot sequences (3+ dots) that might be interpreted as ".."
+		if part == ".." || (len(part) >= 3 && strings.Trim(part, ".") == "") {
+			return fmt.Errorf("invalid file path: %s", name)
+		}
+	}
+
+	if flatten {
+		name = filepath.Base(name)
+	}
+
+	// Validate file name before path construction to catch absolute paths and other attacks
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("invalid file path, absolute path not allowed: %s", name)
+	}
+
+	// Check for Windows-style absolute paths and UNC paths (platform-independent)
+	if len(name) >= 3 && name[1] == ':' && (name[2] == '\\' || name[2] == '/') {
+		return fmt.Errorf("invalid file path, Windows drive path not allowed: %s", name)
+	}
+	if strings.HasPrefix(name, "\\\\") {
+		return fmt.Errorf("invalid file path, UNC path not allowed: %s", name)
+	}
+
+	fpath := filepath.Join(dest, name)
+
+	// Canonicalize paths and validate against directory traversal
+	destRoot := filepath.Clean(dest)
+	if !strings.HasSuffix(destRoot, string(os.PathSeparator)) {
+		destRoot += string(os.PathSeparator)
+	}
+	cleanedFpath := filepath.Clean(fpath)
+
+	// Ensure the cleaned file path is within the destination directory
+	if !strings.HasPrefix(cleanedFpath+string(os.PathSeparator), destRoot) {
+		return fmt.Errorf("invalid file path, outside destination directory: %s", name)
+	}
+
+	if f.FileInfo().IsDir() && !flatten {
+		return os.MkdirAll(fpath, os.ModePerm)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+		return err
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	// Zip archives created on Windows may store zero or incorrect Unix
+	// permission bits, causing EACCES errors when the extracted files
+	// are read on Linux.  Ensure the owner-read bit is always present
+	// while preserving any existing execute bits.
+	mode := f.Mode()
+	if mode.Perm() == 0 {
+		// Entirely missing permissions — set sensible default but
+		// keep any execute bits from the original mode.
+		mode = (mode & 0o111) | 0o600
+	} else if mode&0o400 == 0 {
+		// Has some bits but owner-read is missing — add it.
+		mode = mode | 0o400
+	}
+
+	out, err := os.OpenFile(
+		fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(out, rc); err != nil {
+		out.Close()
+		return err
+	}
+
+	return out.Close()
 }

--- a/sys/io.go
+++ b/sys/io.go
@@ -426,11 +426,20 @@ func unzipFile(f *zip.File, dest string, flatten bool) error {
 	fpath := filepath.Join(dest, name)
 
 	// Canonicalize paths and validate against directory traversal
-	destRoot := filepath.Clean(dest)
+	destRoot, err := filepath.Abs(dest)
+	if err != nil {
+		return fmt.Errorf("invalid destination path: %w", err)
+	}
+	cleanedFpath, err := filepath.Abs(fpath)
+	if err != nil {
+		return fmt.Errorf("invalid file path: %w", err)
+	}
+
+	destRoot = filepath.Clean(destRoot)
 	if !strings.HasSuffix(destRoot, string(os.PathSeparator)) {
 		destRoot += string(os.PathSeparator)
 	}
-	cleanedFpath := filepath.Clean(fpath)
+	cleanedFpath = filepath.Clean(cleanedFpath)
 
 	// Ensure the cleaned file path is within the destination directory
 	if !strings.HasPrefix(cleanedFpath+string(os.PathSeparator), destRoot) {

--- a/sys/io_test.go
+++ b/sys/io_test.go
@@ -45,6 +45,30 @@ func TestUnzip(t *testing.T) {
 	assert.True(t, Exists(filepath.Join(baseDir, "foo", "foo.txt")))
 }
 
+func TestUnzipRelativeDestination(t *testing.T) {
+	baseDir := t.TempDir()
+	zipPath := filepath.Join(baseDir, "foobar.zip")
+	zf, err := os.Create(zipPath)
+	assert.NoError(t, err)
+	zw := zip.NewWriter(zf)
+	w, err := zw.Create("foo/foo.txt")
+	assert.NoError(t, err)
+	_, err = w.Write([]byte("bar"))
+	assert.NoError(t, err)
+	assert.NoError(t, zw.Close())
+	assert.NoError(t, zf.Close())
+
+	originalWd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(baseDir))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(originalWd))
+	})
+
+	assert.NoError(t, Unzip("foobar.zip", ".", false))
+	assert.True(t, Exists(filepath.Join(baseDir, "foo", "foo.txt")))
+}
+
 func TestUnzipWithBracketFilename(t *testing.T) {
 	baseDir := t.TempDir()
 	zipPath := filepath.Join(baseDir, "test.zip")

--- a/sys/io_unix_test.go
+++ b/sys/io_unix_test.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package sys
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestUnzipClosesEachEntry(t *testing.T) {
+	baseDir := t.TempDir()
+	zipPath := filepath.Join(baseDir, "many-files.zip")
+
+	files := make(map[string]string)
+	for i := 0; i < 64; i++ {
+		files[fmt.Sprintf("node_modules/pkg_%02d/index.js", i)] = fmt.Sprintf("module.exports = %d\n", i)
+	}
+	writeUnzipTestArchive(t, zipPath, files)
+
+	openFDs, err := countOpenFDs()
+	if err != nil {
+		t.Skipf("cannot count open file descriptors: %v", err)
+	}
+
+	var original syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &original); err != nil {
+		t.Skipf("cannot read RLIMIT_NOFILE: %v", err)
+	}
+
+	target := uint64(openFDs + 32)
+	if target < 64 {
+		target = 64
+	}
+	if original.Cur <= target || original.Max < target {
+		t.Skipf("RLIMIT_NOFILE is too low for deterministic test: open=%d cur=%d max=%d target=%d", openFDs, original.Cur, original.Max, target)
+	}
+
+	limited := original
+	limited.Cur = target
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limited); err != nil {
+		t.Skipf("cannot lower RLIMIT_NOFILE: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &original); err != nil {
+			t.Logf("failed to restore RLIMIT_NOFILE: %v", err)
+		}
+	})
+
+	extractDir := filepath.Join(baseDir, "out")
+	if err := Unzip(zipPath, extractDir, false); err != nil {
+		t.Fatalf("Unzip returned error under low RLIMIT_NOFILE: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(extractDir, "node_modules/pkg_63/index.js"))
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(got) != "module.exports = 63\n" {
+		t.Fatalf("extracted content = %q", got)
+	}
+}
+
+func writeUnzipTestArchive(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	out, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	defer out.Close()
+
+	zw := zip.NewWriter(out)
+	for name, contents := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %q: %v", name, err)
+		}
+		if _, err := w.Write([]byte(contents)); err != nil {
+			t.Fatalf("write zip entry %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+}
+
+func countOpenFDs() (int, error) {
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			return len(entries), nil
+		}
+	}
+	return 0, os.ErrNotExist
+}


### PR DESCRIPTION
## Summary

- scopes zip entry reader and output file closes to each archive entry in `sys.Unzip`
- avoids accumulating file descriptors while extracting large archives with many files
- adds a Unix regression test that lowers `RLIMIT_NOFILE` and extracts a many-entry archive

## Context

Hadron deployment warmup has failed on large Genesis deployment zips with:

```text
error unzipping .../source.zip: open .../node_modules/...: too many open files
```

The immediate cause is that `sys.Unzip` deferred entry reader and output file closes inside the archive loop, keeping descriptors open until the entire unzip returned.

## Validation

```bash
go test ./sys -run 'TestUnzip|TestTarGz'
go test ./...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened zip extraction to block unsafe/absolute paths, prevent directory traversal, and ensure extracted files remain within the target directory.
  * Ensured extracted files have sensible permissions to allow owner-read and preserve executable bits.

* **Refactor**
  * Reorganized extraction flow for improved reliability and maintainability.

* **Tests**
  * Added tests verifying resource cleanup under constrained file-descriptor limits and correct behavior when using a relative extraction destination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/go-common/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->