### PR TITLE
Fix Gravity metadata nil session client panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agentuity/go-common
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/gravity/control_stream_resilience_test.go
+++ b/gravity/control_stream_resilience_test.go
@@ -17,9 +17,15 @@ import (
 type mockSessionClient struct {
 	establishErr     error
 	streamPacketsErr error
+	deploymentResp   *pb.DeploymentMetadataResponse
+	deploymentErr    error
+	sandboxResp      *pb.SandboxMetadataResponse
+	sandboxErr       error
 
 	establishCalls     int
 	streamPacketsCalls int
+	deploymentCalls    int
+	sandboxCalls       int
 }
 
 func (m *mockSessionClient) EstablishSession(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[pb.SessionMessage, pb.SessionMessage], error) {
@@ -39,10 +45,24 @@ func (m *mockSessionClient) StreamSessionPackets(ctx context.Context, opts ...gr
 }
 
 func (m *mockSessionClient) GetDeploymentMetadata(context.Context, *pb.DeploymentMetadataRequest, ...grpc.CallOption) (*pb.DeploymentMetadataResponse, error) {
+	m.deploymentCalls++
+	if m.deploymentErr != nil {
+		return nil, m.deploymentErr
+	}
+	if m.deploymentResp != nil {
+		return m.deploymentResp, nil
+	}
 	return nil, errors.New("not implemented")
 }
 
 func (m *mockSessionClient) GetSandboxMetadata(context.Context, *pb.SandboxMetadataRequest, ...grpc.CallOption) (*pb.SandboxMetadataResponse, error) {
+	m.sandboxCalls++
+	if m.sandboxErr != nil {
+		return nil, m.sandboxErr
+	}
+	if m.sandboxResp != nil {
+		return m.sandboxResp, nil
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -252,6 +272,50 @@ func TestEstablishControlStreams_SingleEndpointNilClientReturnsError(t *testing.
 	}
 	if g.endpointReconnecting[0].Load() {
 		t.Fatalf("expected single-endpoint reconnecting flag to remain false")
+	}
+}
+
+func TestGetDeploymentMetadata_NoSessionClientsReturnsError(t *testing.T) {
+	g := newResilienceTestClient(t, 0, false)
+
+	resp, err := g.GetDeploymentMetadata(context.Background(), "deploy-1", "org-1")
+	if err == nil {
+		t.Fatalf("expected error for empty session clients, got response: %v", resp)
+	}
+	if !strings.Contains(err.Error(), "no gRPC session clients available") {
+		t.Fatalf("expected no clients error, got: %v", err)
+	}
+}
+
+func TestGetDeploymentMetadata_AllNilSessionClientsReturnsError(t *testing.T) {
+	g := newResilienceTestClient(t, 2, true)
+	g.sessionClients = []pb.GravitySessionServiceClient{nil, nil}
+
+	resp, err := g.GetDeploymentMetadata(context.Background(), "deploy-1", "org-1")
+	if err == nil {
+		t.Fatalf("expected error for nil session clients, got response: %v", resp)
+	}
+	if !strings.Contains(err.Error(), "no usable gRPC session clients available") {
+		t.Fatalf("expected no usable clients error, got: %v", err)
+	}
+}
+
+func TestGetDeploymentMetadata_UsesLaterNonNilSessionClient(t *testing.T) {
+	g := newResilienceTestClient(t, 3, true)
+	laterClient := &mockSessionClient{
+		deploymentResp: &pb.DeploymentMetadataResponse{Success: true},
+	}
+	g.sessionClients = []pb.GravitySessionServiceClient{nil, laterClient, nil}
+
+	resp, err := g.GetDeploymentMetadata(context.Background(), "deploy-1", "org-1")
+	if err != nil {
+		t.Fatalf("expected success from later session client, got error: %v", err)
+	}
+	if resp == nil || !resp.GetSuccess() {
+		t.Fatalf("expected successful deployment metadata response, got: %v", resp)
+	}
+	if laterClient.deploymentCalls != 1 {
+		t.Fatalf("expected later client to be called once, got %d", laterClient.deploymentCalls)
 	}
 }
 

--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -7044,10 +7044,26 @@ func (g *GravityClient) returnBuffer(pooledBuf *PooledBuffer) {
 	}
 }
 
-// GetDeploymentMetadata makes a gRPC call to get deployment metadata
-func (g *GravityClient) GetDeploymentMetadata(ctx context.Context, deploymentID, orgID string) (*pb.DeploymentMetadataResponse, error) {
+func (g *GravityClient) usableSessionClient() (pb.GravitySessionServiceClient, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
 	if len(g.sessionClients) == 0 {
 		return nil, fmt.Errorf("no gRPC session clients available")
+	}
+	for _, client := range g.sessionClients {
+		if client != nil {
+			return client, nil
+		}
+	}
+	return nil, fmt.Errorf("no usable gRPC session clients available")
+}
+
+// GetDeploymentMetadata makes a gRPC call to get deployment metadata
+func (g *GravityClient) GetDeploymentMetadata(ctx context.Context, deploymentID, orgID string) (*pb.DeploymentMetadataResponse, error) {
+	client, err := g.usableSessionClient()
+	if err != nil {
+		return nil, err
 	}
 
 	metadataRequest := &pb.DeploymentMetadataRequest{
@@ -7058,13 +7074,14 @@ func (g *GravityClient) GetDeploymentMetadata(ctx context.Context, deploymentID,
 	md := metadata.Pairs("authorization", "Bearer "+g.authorizationToken)
 	authCtx := metadata.NewOutgoingContext(ctx, md)
 
-	return g.sessionClients[0].GetDeploymentMetadata(authCtx, metadataRequest)
+	return client.GetDeploymentMetadata(authCtx, metadataRequest)
 }
 
 // GetSandboxMetadata makes a gRPC call to get sandbox metadata
 func (g *GravityClient) GetSandboxMetadata(ctx context.Context, sandboxID, orgID string, generateCertificate bool) (*pb.SandboxMetadataResponse, error) {
-	if len(g.sessionClients) == 0 {
-		return nil, fmt.Errorf("no gRPC session clients available")
+	client, err := g.usableSessionClient()
+	if err != nil {
+		return nil, err
 	}
 
 	metadataRequest := &pb.SandboxMetadataRequest{
@@ -7076,7 +7093,7 @@ func (g *GravityClient) GetSandboxMetadata(ctx context.Context, sandboxID, orgID
 	md := metadata.Pairs("authorization", "Bearer "+g.authorizationToken)
 	authCtx := metadata.NewOutgoingContext(ctx, md)
 
-	return g.sessionClients[0].GetSandboxMetadata(authCtx, metadataRequest)
+	return client.GetSandboxMetadata(authCtx, metadataRequest)
 }
 
 // GetIPv6Address returns the IPv6 address for external use


### PR DESCRIPTION
## Summary
- select a non-nil Gravity session client for metadata calls instead of directly using sessionClients[0]
- return a normal error when no usable session client exists
- add regression coverage for empty, all-nil, and nil-first session client slices
- update go.mod to Go 1.26.4

## Test
- go test ./gravity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience for deployment and sandbox metadata retrieval to properly handle situations where session clients are unavailable, automatically routing requests to available alternatives.

* **Tests**
  * Added comprehensive test coverage for deployment metadata retrieval, including proper error handling when no session clients are available and automatic fallback routing behavior.

* **Chores**
  * Updated Go toolchain version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->