### PR TITLE
Throttle durable log vacuum and expose log write batch options

### DIFF
--- a/telemetry/log_batcher.go
+++ b/telemetry/log_batcher.go
@@ -112,7 +112,12 @@ type durableLogProcessor struct {
 
 	stopped atomic.Bool
 	dropped atomic.Uint64
+
+	limitsMu      sync.Mutex
+	lastVacuumAt  time.Time
 }
+
+const incrementalVacuumMinInterval = 5 * time.Minute
 
 var _ sdklog.Processor = (*durableLogProcessor)(nil)
 
@@ -236,6 +241,7 @@ func (p *durableLogProcessor) Shutdown(ctx context.Context) error {
 		return errors.Join(ctx.Err(), p.exporter.Shutdown(ctx), p.db.Close())
 	}
 	err := p.drain(ctx)
+	p.maybeIncrementalVacuum()
 	return errors.Join(err, p.exporter.Shutdown(ctx), p.db.Close())
 }
 
@@ -332,8 +338,19 @@ func (p *durableLogProcessor) enforceLimits() error {
 		}
 		totalBytes -= size
 	}
-	_, _ = p.db.Exec(`PRAGMA incremental_vacuum`)
+	p.maybeIncrementalVacuum()
 	return err
+}
+
+func (p *durableLogProcessor) maybeIncrementalVacuum() {
+	p.limitsMu.Lock()
+	defer p.limitsMu.Unlock()
+	now := time.Now()
+	if !p.lastVacuumAt.IsZero() && now.Sub(p.lastVacuumAt) < incrementalVacuumMinInterval {
+		return
+	}
+	p.lastVacuumAt = now
+	_, _ = p.db.Exec(`PRAGMA incremental_vacuum`)
 }
 
 func configureDurableQueueDB(ctx context.Context, db *sql.DB) error {

--- a/telemetry/log_batcher.go
+++ b/telemetry/log_batcher.go
@@ -241,7 +241,7 @@ func (p *durableLogProcessor) Shutdown(ctx context.Context) error {
 		return errors.Join(ctx.Err(), p.exporter.Shutdown(ctx), p.db.Close())
 	}
 	err := p.drain(ctx)
-	p.maybeIncrementalVacuum()
+	p.maybeIncrementalVacuum(true)
 	return errors.Join(err, p.exporter.Shutdown(ctx), p.db.Close())
 }
 
@@ -338,18 +338,20 @@ func (p *durableLogProcessor) enforceLimits() error {
 		}
 		totalBytes -= size
 	}
-	p.maybeIncrementalVacuum()
+	p.maybeIncrementalVacuum(false)
 	return err
 }
 
-func (p *durableLogProcessor) maybeIncrementalVacuum() {
+func (p *durableLogProcessor) maybeIncrementalVacuum(force bool) {
 	p.limitsMu.Lock()
 	defer p.limitsMu.Unlock()
-	now := time.Now()
-	if !p.lastVacuumAt.IsZero() && now.Sub(p.lastVacuumAt) < incrementalVacuumMinInterval {
-		return
+	if !force {
+		now := time.Now()
+		if !p.lastVacuumAt.IsZero() && now.Sub(p.lastVacuumAt) < incrementalVacuumMinInterval {
+			return
+		}
+		p.lastVacuumAt = now
 	}
-	p.lastVacuumAt = now
 	_, _ = p.db.Exec(`PRAGMA incremental_vacuum`)
 }
 

--- a/telemetry/otel.go
+++ b/telemetry/otel.go
@@ -130,6 +130,18 @@ func WithLogEmitQueueSize(n int) Option {
 	}
 }
 
+func WithLogWriteInterval(d time.Duration) Option {
+	return func(c *config) {
+		c.logBatch.writeInterval = d
+	}
+}
+
+func WithLogWriteBatchSize(n int) Option {
+	return func(c *config) {
+		c.logBatch.writeBatchSize = n
+	}
+}
+
 func WithMetricBatchPath(path string) Option {
 	return func(c *config) {
 		c.metricBatch.path = path


### PR DESCRIPTION
## Summary
- Throttle `PRAGMA incremental_vacuum` in the durable OTEL log processor to at most once every five minutes instead of on every batch insert
- Always run vacuum on processor shutdown so queued DB files still get compacted on teardown
- Add `WithLogWriteInterval` and `WithLogWriteBatchSize` options so callers (e.g. hadron container log forwarders) can reduce SQLite write frequency when lower CPU matters more than minimum delivery latency

## Context
Production hadron CPU profiling on us-central showed ~68% of hadron CPU in `durableLogProcessor` (`insert` → `enforceLimits` → `incremental_vacuum`) with one SQLite DB per container log forwarder. This change targets the vacuum hot path; hadron will use the new write options in a follow-up infra PR.

## Test plan
- [x] `go test ./telemetry/...`
- [ ] Tag release after merge so infra can bump hadron dependency

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new telemetry configuration options to control log write interval and batch size.

* **Bug Fixes**
  * Improved handling of storage cleanup so vacuum operations run less aggressively and are better spaced out.
  * Ensured cleanup can also run during shutdown for more consistent log maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->