### PR TITLE
fix(dns): filter cloud metadata from recursive upstreams

### DIFF
--- a/dns/resolv.go
+++ b/dns/resolv.go
@@ -18,7 +18,11 @@ type ParsedResolvConf struct {
 }
 
 // ParseResolvConf parses a resolv.conf file and returns the nameservers and search domains.
-// It skips nameservers pointing to 127.0.0.1 (any port) to avoid circular references.
+// It skips nameservers that are unsuitable as recursive upstreams:
+//   - loopback (127.0.0.0/8, ::1) to avoid circular references to a local stub
+//   - cloud metadata / link-local (169.254.169.254 and 169.254.0.0/16) which are
+//     not portable recursive resolvers (on Azure, 169.254.169.254 is IMDS, not DNS)
+//
 // If filename is empty, it defaults to /etc/resolv.conf
 func ParseResolvConf(filename string) (*ParsedResolvConf, error) {
 	if filename == "" {
@@ -50,8 +54,8 @@ func ParseResolvConf(filename string) (*ParsedResolvConf, error) {
 		switch fields[0] {
 		case "nameserver":
 			ns := fields[1]
-			// Skip localhost/loopback addresses to avoid circular references
-			if isLoopbackAddress(ns) {
+			// Skip addresses that must not be used as recursive upstreams.
+			if isUnsuitableUpstreamNameserver(ns) {
 				continue
 			}
 			// Add port 53 if not specified
@@ -87,30 +91,61 @@ func ParseResolvConf(filename string) (*ParsedResolvConf, error) {
 	return result, nil
 }
 
-// isLoopbackAddress checks if an address is a loopback address (127.0.0.0/8 or ::1)
-func isLoopbackAddress(addr string) bool {
-	// Remove port if present
+// nameserverHost extracts the host portion of a nameserver address that may
+// include a port (e.g. "8.8.8.8:53", "[2001:db8::1]:53", or bare "8.8.8.8").
+func nameserverHost(addr string) string {
 	host := addr
 	if strings.Contains(addr, ":") {
-		var err error
-		host, _, err = net.SplitHostPort(addr)
-		if err != nil {
-			// Maybe it's just an IP without port, or IPv6
-			host = addr
+		h, _, err := net.SplitHostPort(addr)
+		if err == nil {
+			return h
 		}
+		// Bare IPv6 without brackets/port, or other non-host:port form.
 	}
+	return host
+}
 
-	ip := net.ParseIP(host)
+// isLoopbackAddress checks if an address is a loopback address (127.0.0.0/8 or ::1)
+func isLoopbackAddress(addr string) bool {
+	ip := net.ParseIP(nameserverHost(addr))
 	if ip == nil {
 		return false
 	}
-
 	return ip.IsLoopback()
 }
 
+// isCloudMetadataNameserver reports whether addr is a cloud instance-metadata
+// or link-local address that must not be used as a recursive DNS upstream.
+//
+// 169.254.169.254 is the multi-cloud metadata endpoint (IMDS). On GCP it
+// sometimes answers DNS; on Azure it is HTTP metadata only and UDP/53 times
+// out. Preferring it as the first upstream burns the local stub's query
+// budget and breaks multi-level CNAME resolution (e.g. Upstash Redis hosts).
+//
+// Broader 169.254.0.0/16 (IPv4 link-local) and fe80::/10 (IPv6 link-local)
+// are also unsuitable as portable recursive resolvers.
+func isCloudMetadataNameserver(addr string) bool {
+	ip := net.ParseIP(nameserverHost(addr))
+	if ip == nil {
+		return false
+	}
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+	// Explicit metadata well-known address (also covered by link-local, kept
+	// for clarity and in case of future non-link-local metadata DNS).
+	return ip.Equal(net.IPv4(169, 254, 169, 254))
+}
+
+// isUnsuitableUpstreamNameserver reports whether addr should be excluded from
+// recursive upstream lists (loopback stub or cloud metadata / link-local).
+func isUnsuitableUpstreamNameserver(addr string) bool {
+	return isLoopbackAddress(addr) || isCloudMetadataNameserver(addr)
+}
+
 // GetSystemNameservers returns a merged list of nameservers: first the nameservers
-// from the system's resolv.conf (excluding loopback addresses), then the
-// DefaultExternalDNSServers as fallbacks. Duplicates are removed.
+// from the system's resolv.conf (excluding loopback and cloud-metadata addresses),
+// then the DefaultExternalDNSServers as fallbacks. Duplicates are removed.
 func GetSystemNameservers() []string {
 	parsed, err := ParseResolvConf(DefaultResolveConfFilename)
 
@@ -120,6 +155,9 @@ func GetSystemNameservers() []string {
 	// Add system nameservers first (if any)
 	if err == nil {
 		for _, ns := range parsed.Nameservers {
+			if isUnsuitableUpstreamNameserver(ns) {
+				continue
+			}
 			if !seen[ns] {
 				seen[ns] = true
 				result = append(result, ns)
@@ -138,23 +176,51 @@ func GetSystemNameservers() []string {
 	return result
 }
 
-// WriteResolvConf writes a resolv.conf file that points to a local DNS server
-// with the default internal domain as the search domain.
+// WriteResolvConf writes a resolv.conf file that points clients at the local
+// DNS stub (127.0.0.1). A public recursive server from DefaultExternalDNSServers
+// is included as a last-resort fallback when the local stub is unavailable.
+//
+// Cloud metadata (169.254.169.254) is intentionally not used: on Azure it is
+// IMDS, not recursive DNS, and caused intermittent lookup timeouts.
+//
 // If filename is empty, it defaults to /etc/resolv.conf
 func WriteResolvConf(filename string) error {
 	if filename == "" {
 		filename = DefaultResolveConfFilename
 	}
 
-	content := `# Generated by agentuity/go-common/dns
-nameserver 127.0.0.1
-nameserver 169.254.169.254
-`
+	var b strings.Builder
+	b.WriteString("# Generated by agentuity/go-common/dns\n")
+	b.WriteString("nameserver 127.0.0.1\n")
+	if fallback := resolvConfNameserverHost(DefaultExternalDNSServers); fallback != "" {
+		b.WriteString("nameserver ")
+		b.WriteString(fallback)
+		b.WriteString("\n")
+	}
 
 	// Write the file with appropriate permissions (0644)
-	if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(b.String()), 0644); err != nil {
 		return fmt.Errorf("failed to write %s: %w", filename, err)
 	}
 
 	return nil
+}
+
+// resolvConfNameserverHost returns the first DefaultExternalDNSServers entry
+// in resolv.conf form (host only, no port). Empty if none configured.
+func resolvConfNameserverHost(servers []string) string {
+	for _, ns := range servers {
+		host := nameserverHost(ns)
+		if host == "" || isUnsuitableUpstreamNameserver(host) {
+			continue
+		}
+		// resolv.conf wants a bare IP or hostname, not host:port.
+		if ip := net.ParseIP(host); ip != nil {
+			return host
+		}
+		if !strings.Contains(host, ":") {
+			return host
+		}
+	}
+	return ""
 }

--- a/dns/resolv_test.go
+++ b/dns/resolv_test.go
@@ -95,27 +95,42 @@ func TestWriteResolvConf_Content(t *testing.T) {
 		t.Fatalf("Failed to read written file: %v", err)
 	}
 
-	lines := strings.Split(string(content), "\n")
+	contentStr := string(content)
+	lines := strings.Split(contentStr, "\n")
 
 	// Track what we found
 	foundComment := false
-	foundNameserver := false
+	foundLocalStub := false
+	foundMetadata := false
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "#") {
 			foundComment = true
 		}
-		if strings.HasPrefix(line, "nameserver 127.0.0.1") {
-			foundNameserver = true
+		if line == "nameserver 127.0.0.1" {
+			foundLocalStub = true
+		}
+		if strings.Contains(line, "169.254.169.254") {
+			foundMetadata = true
 		}
 	}
 
 	if !foundComment {
 		t.Error("resolv.conf missing comment header")
 	}
-	if !foundNameserver {
-		t.Error("resolv.conf missing nameserver line")
+	if !foundLocalStub {
+		t.Error("resolv.conf missing local stub nameserver 127.0.0.1")
+	}
+	if foundMetadata {
+		t.Error("resolv.conf must not list cloud metadata 169.254.169.254 as a nameserver")
+	}
+	// Public recursive fallback (first DefaultExternalDNSServers host) should be present.
+	if fallback := resolvConfNameserverHost(DefaultExternalDNSServers); fallback != "" {
+		want := "nameserver " + fallback
+		if !strings.Contains(contentStr, want) {
+			t.Errorf("resolv.conf missing public fallback %q; content:\n%s", want, contentStr)
+		}
 	}
 }
 
@@ -264,6 +279,44 @@ nameserver 127.0.0.53
 			wantErr:         false,
 		},
 		{
+			name: "skip cloud metadata 169.254.169.254",
+			content: `nameserver 169.254.169.254
+nameserver 8.8.8.8
+nameserver 9.9.9.9
+`,
+			wantNameservers: []string{"8.8.8.8:53", "9.9.9.9:53"},
+			wantSearch:      nil,
+			wantErr:         false,
+		},
+		{
+			name: "skip metadata with port and other link-local",
+			content: `nameserver 169.254.169.254:53
+nameserver 169.254.0.1
+nameserver 10.0.2.3
+`,
+			wantNameservers: []string{"10.0.2.3:53"},
+			wantSearch:      nil,
+			wantErr:         false,
+		},
+		{
+			name: "azure style: metadata then real dns kept",
+			content: `nameserver 169.254.169.254
+nameserver 168.63.129.16
+`,
+			wantNameservers: []string{"168.63.129.16:53"},
+			wantSearch:      nil,
+			wantErr:         false,
+		},
+		{
+			name: "only metadata - no valid nameservers",
+			content: `nameserver 169.254.169.254
+nameserver 169.254.0.1
+`,
+			wantNameservers: nil,
+			wantSearch:      nil,
+			wantErr:         false,
+		},
+		{
 			name: "extra whitespace",
 			content: `  nameserver   8.8.8.8  
   search   example.com  
@@ -338,6 +391,7 @@ func TestIsLoopbackAddress(t *testing.T) {
 		{"8.8.8.8", false},
 		{"1.1.1.1", false},
 		{"0.0.0.0", false},
+		{"169.254.169.254", false},
 		{"", false},
 		{"invalid", false},
 	}
@@ -346,6 +400,59 @@ func TestIsLoopbackAddress(t *testing.T) {
 		t.Run(tt.addr, func(t *testing.T) {
 			if got := isLoopbackAddress(tt.addr); got != tt.want {
 				t.Errorf("isLoopbackAddress(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsCloudMetadataNameserver(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"169.254.169.254", true},
+		{"169.254.169.254:53", true},
+		{"169.254.0.1", true},      // IPv4 link-local
+		{"169.254.255.255", true},  // IPv4 link-local
+		{"fe80::1", true},          // IPv6 link-local
+		{"[fe80::1]:53", true},
+		{"8.8.8.8", false},
+		{"9.9.9.9:53", false},
+		{"10.0.2.3", false},
+		{"168.63.129.16", false}, // Azure recursive DNS (not metadata)
+		{"127.0.0.1", false},
+		{"", false},
+		{"invalid", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			if got := isCloudMetadataNameserver(tt.addr); got != tt.want {
+				t.Errorf("isCloudMetadataNameserver(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUnsuitableUpstreamNameserver(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"127.0.0.53:53", true},
+		{"169.254.169.254", true},
+		{"169.254.169.254:53", true},
+		{"8.8.8.8", false},
+		{"9.9.9.9:53", false},
+		{"168.63.129.16", false},
+		{"10.0.2.3:53", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			if got := isUnsuitableUpstreamNameserver(tt.addr); got != tt.want {
+				t.Errorf("isUnsuitableUpstreamNameserver(%q) = %v, want %v", tt.addr, got, tt.want)
 			}
 		})
 	}
@@ -427,5 +534,48 @@ nameserver 10.0.2.3
 
 	if count != 1 {
 		t.Errorf("Expected 9.9.9.9:53 to appear exactly once, got %d times in %v", count, result)
+	}
+}
+
+func TestGetSystemNameservers_FiltersCloudMetadata(t *testing.T) {
+	origDefault := DefaultResolveConfFilename
+	defer func() { DefaultResolveConfFilename = origDefault }()
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "resolv.conf")
+	// Azure-like pre-overwrite resolv.conf: metadata first, then cloud DNS.
+	content := `nameserver 169.254.169.254
+nameserver 168.63.129.16
+`
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	DefaultResolveConfFilename = testFile
+
+	result := GetSystemNameservers()
+
+	for _, ns := range result {
+		if strings.Contains(ns, "169.254.") {
+			t.Fatalf("GetSystemNameservers() must not return metadata/link-local NS, got %v", result)
+		}
+	}
+	if len(result) == 0 {
+		t.Fatal("GetSystemNameservers() returned empty list")
+	}
+	if result[0] != "168.63.129.16:53" {
+		t.Errorf("expected Azure DNS first, got %v", result)
+	}
+	// Defaults still appended
+	hasDefault := false
+	for _, ns := range result {
+		for _, def := range DefaultExternalDNSServers {
+			if ns == def {
+				hasDefault = true
+			}
+		}
+	}
+	if !hasDefault {
+		t.Errorf("expected default external NS in %v", result)
 	}
 }


### PR DESCRIPTION
## Summary

- Filter cloud metadata / link-local addresses (`169.254.169.254`, `169.254.0.0/16`, `fe80::/10`) out of recursive DNS upstream selection in `ParseResolvConf` and `GetSystemNameservers`.
- Stop writing `169.254.169.254` as a secondary nameserver in `WriteResolvConf`; use a public recursive fallback from `DefaultExternalDNSServers` instead.
- Keep real cloud DNS when present (e.g. Azure `168.63.129.16`).

## Context

On multi-cloud ion, the local `--dns-resolver` stub was starting with:

```text
Upstream nameservers: [169.254.169.254:53, 9.9.9.9:53, 1.1.1.1:53, 8.8.8.8:53]
```

On **Azure**, `169.254.169.254` is IMDS (HTTP metadata), not recursive DNS — UDP/53 times out. Preferring it first burned the 5s query budget and broke multi-level CNAME resolution (e.g. Upstash `main-cow-*.upstash.io` used by Aether Redis), which showed up as:

- `Failed to resolve CNAME chain: all nameservers failed`
- `redis.dial: lookup main-cow-….upstash.io: i/o timeout`
- deployment failures at **promotion** (DNS CNAME registration via Aether Redis)

On **GCP**, metadata DNS works, but it is still a fragile first hop for multi-provider recursion; filtering it is the correct multi-cloud default.

## Test plan

- [x] `go test ./dns/`
- [ ] CI green
- [ ] After release: bump `go-common` in gluon/ion, roll Azure `v1-uswest` ion, confirm upstream list no longer starts with `169.254.169.254`
- [ ] Confirm `Failed to resolve CNAME chain` / Upstash redis dial timeouts drop on Azure
- [ ] Redeploy a project in `usw` Azure and confirm promotion succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS server selection by excluding loopback, cloud metadata, and link-local addresses.
  * Prevented generated resolver configuration from using cloud metadata addresses.
  * Added safer public DNS fallback handling, including support for addresses with ports and bracketed IPv6 formats.
  * Preserved valid system DNS ordering while filtering unsuitable entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->