### PR TITLE
fix(dns): do not cache incomplete CNAME answers

### DIFF
--- a/dns/server.go
+++ b/dns/server.go
@@ -532,7 +532,15 @@ func (s *DNSResolver) forwardQueryTCP(originalData []byte, domain string, queryT
 				cnameNameservers := s.selectNameservers(cnameTarget)
 				finalResponse, err := s.resolveCNAMERecursively(ctx, cnameTarget, queryType, cnameNameservers, 1)
 				if err != nil {
-					s.logger.Error("Failed to resolve CNAME chain: %v", err)
+					s.logger.Error("Failed to resolve CNAME chain: domain=%s qtype=%s cname=%s error=%v",
+						domain, dns.TypeToString[queryType], strings.TrimSuffix(cnameTarget, "."), err)
+					// Incomplete CNAME answers poison the cache and break clients
+					// (e.g. multi-level Upstash CNAMEs). Try the next nameserver.
+					failedResponses++
+					if failedResponses == responsesReceived && nextNS < len(nameservers) {
+						staggerTimer.Reset(0)
+					}
+					continue
 				} else if finalResponse != nil {
 					finalResponse.MsgHdr = response.MsgHdr
 					finalResponse.Question = response.Question
@@ -542,10 +550,15 @@ func (s *DNSResolver) forwardQueryTCP(originalData []byte, domain string, queryT
 				}
 			}
 
-			// Cache the response
-			responseBytes, err := response.Pack()
-			if err == nil {
-				s.cacheResponse(cacheKey, responseBytes, response, domain, queryType)
+			// Never cache CNAME-only answers for A/AAAA queries.
+			if !s.shouldCacheResponse(response, queryType) {
+				s.logger.Debug("skipping cache for incomplete CNAME response: domain=%s qtype=%s",
+					domain, dns.TypeToString[queryType])
+			} else {
+				responseBytes, err := response.Pack()
+				if err == nil {
+					s.cacheResponse(cacheKey, responseBytes, response, domain, queryType)
+				}
 			}
 
 			return response
@@ -780,8 +793,15 @@ func (s *DNSResolver) forwardQuery(conn *net.UDPConn, originalData []byte, domai
 				// Recursively resolve the CNAME
 				finalResponse, err := s.resolveCNAMERecursively(ctx, cnameTarget, queryType, cnameNameservers, 1)
 				if err != nil {
-					s.logger.Error("Failed to resolve CNAME chain: %v", err)
-					// Fall back to sending the partial CNAME response
+					s.logger.Error("Failed to resolve CNAME chain: domain=%s qtype=%s cname=%s error=%v",
+						domain, dns.TypeToString[queryType], strings.TrimSuffix(cnameTarget, "."), err)
+					// Incomplete CNAME answers poison the cache and break clients
+					// (e.g. multi-level Upstash CNAMEs). Try the next nameserver.
+					failedResponses++
+					if failedResponses == responsesReceived && nextNS < len(nameservers) {
+						staggerTimer.Reset(0)
+					}
+					continue
 				} else if finalResponse != nil {
 					// Merge CNAME records with final response
 					finalResponse.MsgHdr = response.MsgHdr     // Preserve original header fields and transaction ID
@@ -799,8 +819,13 @@ func (s *DNSResolver) forwardQuery(conn *net.UDPConn, originalData []byte, domai
 				continue
 			}
 
-			// Cache the response using the minimum TTL from all answers
-			s.cacheResponse(cacheKey, responseBytes, response, domain, queryType)
+			// Never cache CNAME-only answers for A/AAAA queries.
+			if !s.shouldCacheResponse(response, queryType) {
+				s.logger.Debug("skipping cache for incomplete CNAME response: domain=%s qtype=%s",
+					domain, dns.TypeToString[queryType])
+			} else {
+				s.cacheResponse(cacheKey, responseBytes, response, domain, queryType)
+			}
 
 			// Send response back to client
 			_, err = conn.WriteToUDP(responseBytes, clientAddr)
@@ -1074,6 +1099,15 @@ func (s *DNSResolver) getNegativeCacheTTL(response *dns.Msg) uint32 {
 
 func (s *DNSResolver) debugDNSResponse(msg *dns.Msg, domain string, queryType uint16) {
 	s.logger.Debug("DNS query %s (%v) response: %s", domain, dns.TypeToString[queryType], msg)
+}
+
+// shouldCacheResponse reports whether a DNS response is safe to put in the
+// resolver cache. Incomplete CNAME-only answers for A/AAAA queries are not
+// cached: when chain resolution fails they would poison subsequent lookups
+// for multi-level CNAMEs (e.g. Upstash latency endpoints).
+func (s *DNSResolver) shouldCacheResponse(response *dns.Msg, queryType uint16) bool {
+	incomplete, _ := s.needsCNAMEResolution(response, queryType)
+	return !incomplete
 }
 
 // needsCNAMEResolution checks if a response contains only CNAME records without final A/AAAA records

--- a/dns/server_test.go
+++ b/dns/server_test.go
@@ -232,6 +232,66 @@ func TestDefaultDNSConfig(t *testing.T) {
 	}
 }
 
+func TestDNSResolver_shouldCacheResponse(t *testing.T) {
+	testLogger := logger.NewTestLogger()
+	config := DNSConfig{
+		ListenAddress:       ":15353",
+		ManagedDomains:      []string{"test.local"},
+		InternalNameservers: []string{"127.0.0.1:5354"},
+		UpstreamNameservers: []string{"8.8.8.8:53"},
+		QueryTimeout:        "2s",
+	}
+
+	resolver, err := New(context.Background(), testLogger, config)
+	if err != nil {
+		t.Fatalf("Failed to create resolver: %v", err)
+	}
+
+	cnameOnly := &dns.Msg{
+		Answer: []dns.RR{
+			&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: "main-cow.upstash.io.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 15},
+				Target: "global-latency.upstash.io.",
+			},
+		},
+	}
+	if resolver.shouldCacheResponse(cnameOnly, dns.TypeA) {
+		t.Error("CNAME-only A response must not be cached")
+	}
+	if resolver.shouldCacheResponse(cnameOnly, dns.TypeAAAA) {
+		t.Error("CNAME-only AAAA response must not be cached")
+	}
+
+	complete := &dns.Msg{
+		Answer: []dns.RR{
+			&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: "main-cow.upstash.io.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 15},
+				Target: "global-latency.upstash.io.",
+			},
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "global-us3.upstash.io.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.IPv4(44, 233, 22, 8),
+			},
+		},
+	}
+	if !resolver.shouldCacheResponse(complete, dns.TypeA) {
+		t.Error("CNAME+A response should be cached")
+	}
+
+	// Pure A answers are always cacheable.
+	aOnly := &dns.Msg{
+		Answer: []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.IPv4(1, 2, 3, 4),
+			},
+		},
+	}
+	if !resolver.shouldCacheResponse(aOnly, dns.TypeA) {
+		t.Error("A-only response should be cached")
+	}
+}
+
 func TestDNSResolver_needsCNAMEResolution(t *testing.T) {
 	logger := logger.NewTestLogger()
 	config := DNSConfig{


### PR DESCRIPTION
## Summary

- When CNAME chain resolution fails for A/AAAA queries, **do not cache** the incomplete CNAME-only answer (UDP and TCP paths).
- On chain failure, **try the next upstream nameserver** instead of returning a poisonable partial answer as a successful cacheable result.
- Improve error logs: `domain=… qtype=… cname=… error=…` so production CNAME failures are debuggable.
- Add `shouldCacheResponse` helper + unit tests.

## Context

Follow-up to #313 (filter cloud metadata from recursive upstreams). After the Azure us-west canary, residual `Failed to resolve CNAME chain` noise was still observed mainly at DNS stub restart. Caching incomplete CNAME answers made brief resolution failures stick for the CNAME TTL and break later clients (including Aether Redis / Upstash multi-level CNAMEs).

## Test plan

- [x] `go test ./dns/`
- [ ] CI green
- [ ] After release + gluon rollout: incomplete CNAME answers are not retained across lookups; error logs include domain/cname

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete CNAME-only DNS responses from being cached for A and AAAA queries.
  * Improved recursive CNAME resolution handling by treating unresolved chains as failures and continuing with other available nameservers.
* **Tests**
  * Added coverage for safe caching behavior across CNAME-only, combined CNAME and address, and address-only responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->