### PR TITLE
fix(gravity): copy packets before async send

### DIFF
--- a/gravity/grpc_client.go
+++ b/gravity/grpc_client.go
@@ -3842,8 +3842,11 @@ func (g *GravityClient) sendOnControlStream(streamIndex int, msg *pb.SessionMess
 // Interface methods
 
 func (g *GravityClient) SendPacket(data []byte) error {
+	// SendPacket is asynchronous, so the caller may reuse data as soon as this
+	// method returns. Give the outbound queue ownership of an immutable copy.
+	packet := append([]byte(nil), data...)
 	select {
-	case g.outboundPackets <- data:
+	case g.outboundPackets <- packet:
 		return nil
 	default:
 		return fmt.Errorf("outbound packet channel full")

--- a/gravity/tunnel_dataplane_test.go
+++ b/gravity/tunnel_dataplane_test.go
@@ -224,6 +224,22 @@ func TestWritePacket_SendsToStream(t *testing.T) {
 	}
 }
 
+func TestSendPacketCopiesCallerBuffer(t *testing.T) {
+	t.Parallel()
+	g, _ := newTunnelDataplaneTestClient(t, 1)
+
+	payload := []byte{0x60, 0, 0, 0, 0, 0, 6, 0x2a}
+	if err := g.SendPacket(payload); err != nil {
+		t.Fatalf("SendPacket error: %v", err)
+	}
+
+	payload[len(payload)-1] = 0xff
+	queued := <-g.outboundPackets
+	if got, want := queued[len(queued)-1], byte(0x2a); got != want {
+		t.Fatalf("queued packet retained caller buffer: got last byte %#x, want %#x", got, want)
+	}
+}
+
 func TestWritePacket_RoundRobinAcrossStreams(t *testing.T) {
 	t.Parallel()
 	g, _ := newTunnelDataplaneTestClient(t, 1)


### PR DESCRIPTION
## Summary
- copy packet buffers before enqueueing them for asynchronous Gravity transmission
- prevent caller buffer reuse from corrupting queued tunnel packets
- add deterministic regression coverage for the ownership boundary

## Context
During the US Central investigation, we audited concurrent gRPC send paths. `go-common` already serializes sends per tunnel/control stream, but `SendPacket` retained the caller-owned byte slice after returning. Callers can legally reuse that buffer before the outbound goroutine transmits it, creating a data race or corrupting the packet.

## Validation
- `go test -race ./gravity -run 'TestSendPacketCopiesCallerBuffer|TestSendPacket_' -count=1`\n- `go test ./gravity/... -count=1`\n- `git diff --check`